### PR TITLE
Update i3c driver

### DIFF
--- a/drivers/i3c/CMakeLists.txt
+++ b/drivers/i3c/CMakeLists.txt
@@ -52,6 +52,13 @@ zephyr_library_sources_ifdef(
 )
 
 zephyr_library_sources_ifdef(
+  CONFIG_I3C_NCT_EXT_DEVICE
+  i3c_nct_ext_device.c
+)
+
+add_subdirectory_ifdef(CONFIG_I3C_SLAVE		slave)
+
+zephyr_library_sources_ifdef(
   CONFIG_I3C_TEST
   i3c_test.c
 )

--- a/drivers/i3c/Kconfig
+++ b/drivers/i3c/Kconfig
@@ -34,6 +34,11 @@ config I3C_USE_GROUP_ADDR
 
 	  Says Y if unsure.
 
+config I3C_TARGET_BUFFER_MODE
+	bool "I3C target driver for buffer mode"
+	help
+	  This is an option to enable buffer mode.
+
 menuconfig I3C_USE_IBI
 	bool "Use In-Band Interrupt (IBI)"
 	default y
@@ -105,6 +110,57 @@ config I3C_CONTROLLER_INIT_PRIORITY
 	  initializing those devices. This is because some devices
 	  may not be addressable until addresses are assigned by
 	  the controller.
+
+config I3C_INIT_RSTACT
+	bool "Perform Reset Action During Bus Initialization"
+	default y
+	help
+	  This determines whether the bus initialization routine
+	  sends a reset action command to I3C targets.
+
+config I3C_RTIO
+	bool "I3C RTIO API"
+	select EXPERIMENTAL
+	select RTIO
+	select RTIO_WORKQ
+	help
+	  API and implementations of I3C for RTIO
+
+if I3C_RTIO
+config I3C_RTIO_SQ_SIZE
+	int "Submission queue size for blocking calls"
+	default 4
+	help
+	  Blocking i3c calls when I3C_RTIO is enabled are copied into a per driver
+	  submission queue. The queue depth determines the number of possible i3c_msg
+	  structs that may be in the array given to i3c_transfer. A sensible default
+	  is going to be 4 given the device address, register address, and a value
+	  to be read or written.
+
+config I3C_RTIO_CQ_SIZE
+	int "Completion queue size for blocking calls"
+	default 4
+	help
+	  Blocking i3c calls when I3C_RTIO is enabled are copied into a per driver
+	  submission queue. The queue depth determines the number of possible i3c_msg
+	  structs that may be in the array given to i3c_transfer. A sensible default
+	  is going to be 4 given the device address, register address, and a value
+	  to be read or written.
+
+config I3C_RTIO_FALLBACK_MSGS
+	int "Number of available i3c_msg structs for the default handler to use"
+	default 4
+	help
+		When RTIO is used with a driver that does not yet implement the submit API
+		natively the submissions are converted back to struct i3c_msg values that
+		are given to i3c_transfer. This requires some number of msgs be available to convert
+		the submissions into on the stack. MISRA rules dictate we must know this in
+		advance.
+
+		In all likelihood 4 is going to work for everyone, but in case you do end up with
+		an issue where you are using RTIO, your driver does not implement submit natively,
+
+endif # I3C_RTIO
 
 comment "Device Drivers"
 

--- a/drivers/i3c/Kconfig.nct
+++ b/drivers/i3c/Kconfig.nct
@@ -19,3 +19,21 @@ config I3C_NCT_DMA
 	default y
 	help
 	  Enable DMA support for nct I3C.
+
+config I3C_NCT_EXT_DEVICE
+	bool "Enable NCT I3C external device support"
+	depends on I3C
+	help
+	  Enable support for NCT I3C external device driver.
+
+comment "Initialization Priority"
+
+config I3C_TARGET_INIT_PRIORITY
+	int "I3C Target Init Priority"
+	# Default is just after CONFIG_KERNEL_INIT_PRIORITY_DEVICE
+	default 50
+	help
+	  This is for setting up I3C target device driver instance
+
+# to support 2.6 only
+source "drivers/i3c/slave/Kconfig"

--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -102,6 +102,41 @@ int i3c_ccc_do_rstact_all(const struct device *controller,
 	return i3c_do_ccc(controller, &ccc_payload);
 }
 
+int i3c_ccc_do_rstact(const struct i3c_device_desc *target,
+			  enum i3c_ccc_rstact_defining_byte action,
+			  bool get,
+			  uint8_t *data)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+	uint8_t def_byte;
+
+	__ASSERT_NO_MSG(target != NULL);
+	__ASSERT_NO_MSG(target->bus != NULL);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	if (get) {
+		__ASSERT_NO_MSG(data != NULL);
+
+		ccc_tgt_payload.rnw = 1;
+		ccc_tgt_payload.data = data;
+		ccc_tgt_payload.data_len = sizeof(*data);
+	} else {
+		ccc_tgt_payload.rnw = 0;
+	}
+
+	ccc_payload.ccc.id = I3C_CCC_RSTACT(false);
+	def_byte = (uint8_t)action;
+	ccc_payload.ccc.data = &def_byte;
+	ccc_payload.ccc.data_len = 1U;
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	return i3c_do_ccc(target->bus, &ccc_payload);
+}
+
 int i3c_ccc_do_rstdaa_all(const struct device *controller)
 {
 	struct i3c_ccc_payload ccc_payload;
@@ -114,12 +149,10 @@ int i3c_ccc_do_rstdaa_all(const struct device *controller)
 	return i3c_do_ccc(controller, &ccc_payload);
 }
 
-int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
+int i3c_ccc_do_setdasa(const struct i3c_device_desc *target, struct i3c_ccc_address da)
 {
-	struct i3c_driver_data *bus_data = (struct i3c_driver_data *)target->bus->data;
 	struct i3c_ccc_payload ccc_payload;
 	struct i3c_ccc_target_payload ccc_tgt_payload;
-	uint8_t dyn_addr;
 
 	__ASSERT_NO_MSG(target != NULL);
 	__ASSERT_NO_MSG(target->bus != NULL);
@@ -128,24 +161,9 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 		return -EINVAL;
 	}
 
-	/*
-	 * Note that the 7-bit address needs to start at bit 1
-	 * (aka left-justified). So shift left by 1;
-	 */
-	dyn_addr = (target->init_dynamic_addr ?
-				target->init_dynamic_addr : target->static_addr) << 1;
-
-	/* check that initial dynamic address is free before setting it */
-	if ((target->init_dynamic_addr != 0) &&
-		(target->init_dynamic_addr != target->static_addr)) {
-		if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots, dyn_addr >> 1)) {
-			return -EINVAL;
-		}
-	}
-
 	ccc_tgt_payload.addr = target->static_addr;
 	ccc_tgt_payload.rnw = 0;
-	ccc_tgt_payload.data = &dyn_addr;
+	ccc_tgt_payload.data = (uint8_t *)&da.addr;
 	ccc_tgt_payload.data_len = 1;
 
 	memset(&ccc_payload, 0, sizeof(ccc_payload));
@@ -158,10 +176,8 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 
 int i3c_ccc_do_setnewda(const struct i3c_device_desc *target, struct i3c_ccc_address new_da)
 {
-	struct i3c_driver_data *bus_data = (struct i3c_driver_data *)target->bus->data;
 	struct i3c_ccc_payload ccc_payload;
 	struct i3c_ccc_target_payload ccc_tgt_payload;
-	uint8_t new_dyn_addr;
 
 	__ASSERT_NO_MSG(target != NULL);
 	__ASSERT_NO_MSG(target->bus != NULL);
@@ -170,22 +186,9 @@ int i3c_ccc_do_setnewda(const struct i3c_device_desc *target, struct i3c_ccc_add
 		return -EINVAL;
 	}
 
-	/*
-	 * Note that the 7-bit address needs to start at bit 1
-	 * (aka left-justified). So shift left by 1;
-	 */
-	new_dyn_addr = new_da.addr << 1;
-
-	/* check that initial dynamic address is free before setting it */
-	if (target->dynamic_addr != new_da.addr) {
-		if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots, new_da.addr)) {
-			return -EINVAL;
-		}
-	}
-
 	ccc_tgt_payload.addr = target->dynamic_addr;
 	ccc_tgt_payload.rnw = 0;
-	ccc_tgt_payload.data = &new_dyn_addr;
+	ccc_tgt_payload.data = (uint8_t *)&new_da.addr;
 	ccc_tgt_payload.data_len = 1;
 
 	memset(&ccc_payload, 0, sizeof(ccc_payload));
@@ -237,6 +240,40 @@ int i3c_ccc_do_events_set(struct i3c_device_desc *target,
 	ccc_payload.targets.num_targets = 1;
 
 	return i3c_do_ccc(target->bus, &ccc_payload);
+}
+
+int i3c_ccc_do_entas(const struct i3c_device_desc *target, uint8_t as)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+
+	__ASSERT_NO_MSG(target != NULL);
+	__ASSERT_NO_MSG(target->bus != NULL);
+	__ASSERT_NO_MSG(as <= 3);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 0;
+
+	ccc_payload.ccc.id = I3C_CCC_ENTAS(as, false);
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	return i3c_do_ccc(target->bus, &ccc_payload);
+}
+
+int i3c_ccc_do_entas_all(const struct device *controller, uint8_t as)
+{
+	struct i3c_ccc_payload ccc_payload;
+
+	__ASSERT_NO_MSG(controller != NULL);
+	__ASSERT_NO_MSG(as <= 3);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_ENTAS(as, true);
+
+	return i3c_do_ccc(controller, &ccc_payload);
 }
 
 int i3c_ccc_do_setmwl_all(const struct device *controller,
@@ -420,6 +457,43 @@ int i3c_ccc_do_getmrl(const struct i3c_device_desc *target,
 	return ret;
 }
 
+int i3c_ccc_do_enttm(const struct device *controller,
+			  enum i3c_ccc_enttm_defbyte defbyte)
+{
+	struct i3c_ccc_payload ccc_payload;
+	uint8_t def_byte;
+
+	__ASSERT_NO_MSG(controller != NULL);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_ENTTM;
+
+	def_byte = (uint8_t)defbyte;
+	ccc_payload.ccc.data = &def_byte;
+	ccc_payload.ccc.data_len = 1U;
+
+	return i3c_do_ccc(controller, &ccc_payload);
+}
+
+int i3c_ccc_do_deftgts_all(const struct device *controller,
+			   struct i3c_ccc_deftgts *deftgts)
+{
+	struct i3c_ccc_payload ccc_payload;
+
+	__ASSERT_NO_MSG(controller != NULL);
+	__ASSERT_NO_MSG(deftgts != NULL);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_DEFTGTS;
+
+	ccc_payload.ccc.data = (uint8_t *)deftgts;
+	ccc_payload.ccc.data_len = sizeof(uint8_t) +
+				   sizeof(struct i3c_ccc_deftgts_active_controller) +
+				   (deftgts->count * sizeof(struct i3c_ccc_deftgts_target));
+
+	return i3c_do_ccc(controller, &ccc_payload);
+}
+
 int i3c_ccc_do_getstatus(const struct i3c_device_desc *target,
 			 union i3c_ccc_getstatus *status,
 			 enum i3c_ccc_getstatus_fmt fmt,
@@ -515,6 +589,8 @@ int i3c_ccc_do_getcaps(const struct i3c_device_desc *target,
 	if (fmt == GETCAPS_FORMAT_1) {
 		/* Could be 1-4 Data Bytes Returned */
 		ccc_tgt_payload.data_len = 4;
+
+		LOG_DBG("GETCAPS_FORMAT_1");
 	} else if (fmt == GETCAPS_FORMAT_2) {
 		switch (defbyte) {
 		case GETCAPS_FORMAT_2_CRCAPS:
@@ -538,6 +614,8 @@ int i3c_ccc_do_getcaps(const struct i3c_device_desc *target,
 		goto out;
 	}
 
+	LOG_DBG("ccc_payload ptr %p", &ccc_payload);
+
 	memset(&ccc_payload, 0, sizeof(ccc_payload));
 	ccc_payload.ccc.id = I3C_CCC_GETCAPS;
 	ccc_payload.targets.payloads = &ccc_tgt_payload;
@@ -556,16 +634,25 @@ int i3c_ccc_do_getcaps(const struct i3c_device_desc *target,
 		/* GETCAPS will return a variable length */
 		len = ccc_tgt_payload.num_xfer;
 
+		LOG_DBG("GETCAPS: len %d", len);
+
 		if (fmt == GETCAPS_FORMAT_1) {
 			memcpy(caps->fmt1.getcaps, data, len);
+
 			/* for values not received, assume default (1'b0) */
 			memset(&caps->fmt1.getcaps[len], 0, sizeof(caps->fmt1.getcaps) - len);
+
+			LOG_DBG("GETCAPS_FORMAT_1: %02x %02x %02x %02x",
+				caps->fmt1.getcaps[0], caps->fmt1.getcaps[1],
+				caps->fmt1.getcaps[2], caps->fmt1.getcaps[3]);
+
 		} else if (fmt == GETCAPS_FORMAT_2) {
 			switch (defbyte) {
 			case GETCAPS_FORMAT_2_CRCAPS:
 				memcpy(caps->fmt2.crcaps, data, len);
 				/* for values not received, assume default (1'b0) */
 				memset(&caps->fmt2.crcaps[len], 0, sizeof(caps->fmt2.crcaps) - len);
+				break;
 			case GETCAPS_FORMAT_2_VTCAPS:
 				memcpy(caps->fmt2.vtcaps, data, len);
 				/* for values not received, assume default (1'b0) */
@@ -589,4 +676,253 @@ int i3c_ccc_do_getcaps(const struct i3c_device_desc *target,
 
 out:
 	return ret;
+}
+
+int i3c_ccc_do_setvendor(const struct i3c_device_desc *target,
+			 uint8_t id,
+			 uint8_t *payload,
+			 size_t len)
+{
+	struct i3c_ccc_payload ccc_payload;
+
+	__ASSERT_NO_MSG(target != NULL);
+
+	/* CCC must be between 0xE0 and 0xFE, the total range of this is 0x1E */
+	if (id > 0x1E) {
+		return -EINVAL;
+	}
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_VENDOR(false, id);
+	ccc_payload.ccc.data = payload;
+	ccc_payload.ccc.data_len = len;
+
+	return i3c_do_ccc(target->bus, &ccc_payload);
+}
+
+int i3c_ccc_do_getvendor(const struct i3c_device_desc *target,
+			 uint8_t id,
+			 uint8_t *payload,
+			 size_t len,
+			 size_t *num_xfer)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+	int ret;
+
+	__ASSERT_NO_MSG(target != NULL);
+
+	/* CCC must be between 0xE0 and 0xFE, the total range of this is 0x1E */
+	if (id > 0x1E) {
+		return -EINVAL;
+	}
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 1;
+	ccc_tgt_payload.data = payload;
+	ccc_tgt_payload.data_len = len;
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_VENDOR(false, id);
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	ret = i3c_do_ccc(target->bus, &ccc_payload);
+
+	if (ret == 0) {
+		*num_xfer = ccc_tgt_payload.num_xfer;
+	}
+
+	return ret;
+}
+
+int i3c_ccc_do_getvendor_defbyte(const struct i3c_device_desc *target,
+				 uint8_t id,
+				 uint8_t defbyte,
+				 uint8_t *payload,
+				 size_t len,
+				 size_t *num_xfer)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+	int ret;
+
+	__ASSERT_NO_MSG(target != NULL);
+
+	/* CCC must be between 0xE0 and 0xFE, the total range of this is 0x1E */
+	if (id > 0x1E) {
+		return -EINVAL;
+	}
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 1;
+	ccc_tgt_payload.data = payload;
+	ccc_tgt_payload.data_len = len;
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_VENDOR(false, id);
+	ccc_payload.ccc.data = &defbyte;
+	ccc_payload.ccc.data_len = 1;
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	ret = i3c_do_ccc(target->bus, &ccc_payload);
+
+	if (ret == 0) {
+		*num_xfer = ccc_tgt_payload.num_xfer;
+	}
+
+	return ret;
+}
+
+int i3c_ccc_do_setvendor_all(const struct device *controller,
+				 uint8_t id,
+				 uint8_t *payload,
+				 size_t len)
+{
+	struct i3c_ccc_payload ccc_payload;
+
+	__ASSERT_NO_MSG(controller != NULL);
+
+	/* CCC must be between 0x61 and 0x7F, the total range of this is 0x1E */
+	if (id > 0x1E) {
+		return -EINVAL;
+	}
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_VENDOR(true, id);
+	ccc_payload.ccc.data = payload;
+	ccc_payload.ccc.data_len = len;
+
+	return i3c_do_ccc(controller, &ccc_payload);
+}
+
+int i3c_ccc_do_setaasa_all(const struct device *controller)
+{
+	struct i3c_ccc_payload ccc_payload;
+
+	__ASSERT_NO_MSG(controller != NULL);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_SETAASA;
+
+	return i3c_do_ccc(controller, &ccc_payload);
+}
+
+#define SIZEOF_FIELD(type, member) sizeof((((type *)0)->member))
+
+int i3c_ccc_do_getmxds(const struct i3c_device_desc *target,
+			 union i3c_ccc_getmxds *mxds,
+			 enum i3c_ccc_getmxds_fmt fmt,
+			 enum i3c_ccc_getmxds_defbyte defbyte)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+	uint8_t defining_byte;
+	uint8_t data[5];
+	uint8_t len;
+	int ret;
+
+	LOG_DBG("getmxds");
+
+	__ASSERT_NO_MSG(target != NULL);
+	__ASSERT_NO_MSG(target->bus != NULL);
+	__ASSERT_NO_MSG(mxds != NULL);
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 1;
+	ccc_tgt_payload.data = &data[0];
+
+	if ((fmt == GETMXDS_FORMAT_1) || (fmt == GETMXDS_FORMAT_2)) {
+		/* Could be 2 or 5 Data Bytes Returned */
+		ccc_tgt_payload.data_len = sizeof(((union i3c_ccc_getmxds *)0)->fmt2);
+	} else if (fmt == GETMXDS_FORMAT_3) {
+		switch (defbyte) {
+		case GETMXDS_FORMAT_3_WRRDTURN:
+			/* Could be 2 or 5 Data Bytes Returned */
+			ccc_tgt_payload.data_len =
+				sizeof(((union i3c_ccc_getmxds *)0)->fmt3.wrrdturn);
+			break;
+		case GETMXDS_FORMAT_3_CRHDLY:
+			/* Only 1 Byte returned */
+			ccc_tgt_payload.data_len =
+				sizeof(((union i3c_ccc_getmxds *)0)->fmt3.crhdly1);
+			break;
+		default:
+			ret = -EINVAL;
+			goto out;
+		}
+	} else {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_GETMXDS;
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	if (fmt == GETMXDS_FORMAT_3) {
+		defining_byte = (uint8_t)defbyte;
+
+		ccc_payload.ccc.data = &defining_byte;
+		ccc_payload.ccc.data_len = 1;
+	}
+
+	ret = i3c_do_ccc(target->bus, &ccc_payload);
+
+	if (ret == 0) {
+		/* GETMXDS will return a variable length */
+		len = ccc_tgt_payload.num_xfer;
+
+		if ((fmt == GETMXDS_FORMAT_1) || (fmt == GETMXDS_FORMAT_2)) {
+			if (len == SIZEOF_FIELD(union i3c_ccc_getmxds, fmt1)) {
+				mxds->fmt1.maxwr = data[0];
+				mxds->fmt1.maxrd = data[1];
+				/* It is unknown wither format 1 or format 2 is returned ahead of
+				 * time
+				 */
+				memset(&mxds->fmt2.maxrdturn, 0, sizeof(mxds->fmt2.maxrdturn));
+			} else if (len == SIZEOF_FIELD(union i3c_ccc_getmxds, fmt2)) {
+				mxds->fmt2.maxwr = data[0];
+				mxds->fmt2.maxrd = data[1];
+				memcpy(&mxds->fmt2.maxrdturn, &data[2],
+				       sizeof(mxds->fmt2.maxrdturn));
+			}
+		} else if (fmt == GETMXDS_FORMAT_3) {
+			switch (defbyte) {
+			case GETMXDS_FORMAT_3_WRRDTURN:
+				memcpy(mxds->fmt3.wrrdturn, data, len);
+				/* for values not received, assume default (1'b0) */
+				memset(&mxds->fmt3.wrrdturn[len], 0,
+				       sizeof(mxds->fmt3.wrrdturn) - len);
+				break;
+			case GETMXDS_FORMAT_3_CRHDLY:
+				mxds->fmt3.crhdly1 = data[0];
+				break;
+			default:
+				break;
+			}
+		}
+	}
+
+out:
+	return ret;
+}
+
+int i3c_ccc_do_setbuscon(const struct device *controller,
+				uint8_t *context, uint16_t length)
+{
+	struct i3c_ccc_payload ccc_payload;
+
+	__ASSERT_NO_MSG(controller != NULL);
+	__ASSERT_NO_MSG(context != NULL);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_SETBUSCON;
+
+	ccc_payload.ccc.data = context;
+	ccc_payload.ccc.data_len = length;
+
+	return i3c_do_ccc(controller, &ccc_payload);
 }

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -5,10 +5,12 @@
  */
 
 #include <string.h>
+#include <stdlib.h>
 
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/slist.h>
+#include <zephyr/sys/byteorder.h>
 
 #include <zephyr/drivers/i3c.h>
 
@@ -46,10 +48,10 @@ void i3c_addr_slots_set(struct i3c_addr_slots *slots,
 
 	bitpos = dev_addr * 2;
 	idx = bitpos / BITS_PER_LONG;
+	bitpos %= BITS_PER_LONG;
 
-	slots->slots[idx] &= ~((unsigned long)I3C_ADDR_SLOT_STATUS_MASK <<
-			       (bitpos % BITS_PER_LONG));
-	slots->slots[idx] |= status << (bitpos % BITS_PER_LONG);
+	slots->slots[idx] &= ~((unsigned long)I3C_ADDR_SLOT_STATUS_MASK << bitpos);
+	slots->slots[idx] |= status << bitpos;
 }
 
 enum i3c_addr_slot_status
@@ -72,8 +74,9 @@ i3c_addr_slots_status(struct i3c_addr_slots *slots,
 
 	bitpos = dev_addr * 2;
 	idx = bitpos / BITS_PER_LONG;
+	bitpos %= BITS_PER_LONG;
 
-	status = slots->slots[idx] >> (bitpos % BITS_PER_LONG);
+	status = slots->slots[idx] >> bitpos;
 	status &= I3C_ADDR_SLOT_STATUS_MASK;
 
 	return status;
@@ -96,6 +99,7 @@ int i3c_addr_slots_init(const struct device *dev)
 	sys_slist_init(&data->attached_dev.devices.i3c);
 	sys_slist_init(&data->attached_dev.devices.i2c);
 
+	/* Address restrictions (ref 5.1.2.2.5, Specification for I3C v1.1.1) */
 	for (i = 0; i <= 7; i++) {
 		/* Addresses 0 to 7 are reserved */
 		i3c_addr_slots_set(&data->attached_dev.addr_slots, i, I3C_ADDR_SLOT_STATUS_RSVD);
@@ -154,6 +158,8 @@ bool i3c_addr_slots_is_free(struct i3c_addr_slots *slots,
 
 	status = i3c_addr_slots_status(slots, dev_addr);
 
+	LOG_DBG("Address %d status %d", dev_addr, status);
+
 	return (status == I3C_ADDR_SLOT_STATUS_FREE);
 }
 
@@ -194,17 +200,15 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
 	return ret;
 }
 
-struct i3c_device_desc *i3c_dev_list_i3c_addr_find(struct i3c_dev_attached_list *dev_list,
+struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct device *dev,
 						   uint8_t addr)
 {
-	sys_snode_t *node;
 	struct i3c_device_desc *ret = NULL;
+	struct i3c_device_desc *desc;
 
-	__ASSERT_NO_MSG(dev_list != NULL);
+	__ASSERT_NO_MSG(dev != NULL);
 
-	SYS_SLIST_FOR_EACH_NODE(&dev_list->devices.i3c, node) {
-		struct i3c_device_desc *desc = (void *)node;
-
+	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
 		if (desc->dynamic_addr == addr) {
 			ret = desc;
 			break;
@@ -214,17 +218,15 @@ struct i3c_device_desc *i3c_dev_list_i3c_addr_find(struct i3c_dev_attached_list 
 	return ret;
 }
 
-struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(struct i3c_dev_attached_list *dev_list,
+struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
 							   uint16_t addr)
 {
-	sys_snode_t *node;
 	struct i3c_i2c_device_desc *ret = NULL;
+	struct i3c_i2c_device_desc *desc;
 
-	__ASSERT_NO_MSG(dev_list != NULL);
+	__ASSERT_NO_MSG(dev != NULL);
 
-	SYS_SLIST_FOR_EACH_NODE(&dev_list->devices.i2c, node) {
-		struct i3c_i2c_device_desc *desc = (void *)node;
-
+	I3C_BUS_FOR_EACH_I2CDEV(dev, desc) {
 		if (desc->addr == addr) {
 			ret = desc;
 			break;
@@ -234,92 +236,48 @@ struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(struct i3c_dev_attached_l
 	return ret;
 }
 
-int i3c_determine_default_addr(struct i3c_device_desc *target, uint8_t *addr)
-{
-	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
-
-	/* If dynamic addr is set, then it assumed that it was assigned by a primary controller */
-	if (target->dynamic_addr == 0) {
-		/* It is assumed that SETDASA or ENTDAA will be run after this */
-		if (target->init_dynamic_addr != 0U) {
-			/* initial dynamic address is requested */
-			if (target->static_addr == 0) {
-				/* SA is set to 0, so DA will be set with ENTDAA */
-				if (i3c_addr_slots_is_free(&data->attached_dev.addr_slots,
-							   target->init_dynamic_addr)) {
-					/* Set DA during ENTDAA */
-					*addr = target->init_dynamic_addr;
-				} else {
-					/* address is not free, get the next one */
-					*addr = i3c_addr_slots_next_free_find(
-						&data->attached_dev.addr_slots, 0);
-				}
-			} else {
-				/* Use the init dynamic address as it's DA, but the RR will need to
-				 * be first set with it's SA to run SETDASA, the RR address will
-				 * need be updated after SETDASA with the request dynamic address
-				 */
-				if (i3c_addr_slots_is_free(&data->attached_dev.addr_slots,
-							   target->static_addr)) {
-					*addr = target->static_addr;
-				} else {
-					/* static address has already been taken */
-					return -EINVAL;
-				}
-			}
-		} else {
-			/* no init dynamic address is requested */
-			if (target->static_addr != 0) {
-				if (i3c_addr_slots_is_free(&data->attached_dev.addr_slots,
-							   target->static_addr)) {
-					/* static exists, set DA with same SA during SETDASA*/
-					*addr = target->static_addr;
-				} else {
-					/* static address has already been taken */
-					return -EINVAL;
-				}
-			} else {
-				/* pick a DA to use */
-				*addr = i3c_addr_slots_next_free_find(
-					&data->attached_dev.addr_slots, 0);
-			}
-		}
-	} else {
-		*addr = target->dynamic_addr;
-	}
-
-	return 0;
-}
-
 int i3c_attach_i3c_device(struct i3c_device_desc *target)
 {
 	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
 	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
-	sys_snode_t *node;
 	uint8_t addr = 0;
 	int status = 0;
+	struct i3c_device_desc *i3c_desc;
 
 	/* check to see if the device has already been attached */
-	if (!sys_slist_is_empty(&data->attached_dev.devices.i3c)) {
-		SYS_SLIST_FOR_EACH_NODE(&data->attached_dev.devices.i3c, node) {
-			if (node == &target->node) {
+	I3C_BUS_FOR_EACH_I3CDEV(target->bus, i3c_desc) {
+		if (i3c_desc == target) {
+
+			LOG_DBG("Device already attached");
+
 				return -EINVAL;
 			}
 		}
-	}
 
-	status = i3c_determine_default_addr(target, &addr);
-	if (status != 0) {
-		return status;
+	LOG_DBG("dynamic_addr %d, static_addr %d", target->dynamic_addr, target->static_addr);
+	addr = target->dynamic_addr ? target->dynamic_addr : target->static_addr;
+
+	/*
+	 * If it has a dynamic addr already assigned or a static address, check that it is free
+	 */
+	if (addr) {
+		if (!i3c_addr_slots_is_free(&data->attached_dev.addr_slots, addr)) {
+
+			LOG_DBG("Address slot is not free");
+
+			return -EINVAL;
+		}
 	}
 
 	sys_slist_append(&data->attached_dev.devices.i3c, &target->node);
 
 	if (api->attach_i3c_device != NULL) {
-		status = api->attach_i3c_device(target->bus, target, addr);
+		status = api->attach_i3c_device(target->bus, target);
 	}
 
+	if (addr) {
 	i3c_addr_slots_mark_i3c(&data->attached_dev.addr_slots, addr);
+	}
 
 	return status;
 }
@@ -376,17 +334,15 @@ int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target)
 {
 	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
 	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
-	sys_snode_t *node;
 	int status = 0;
+	struct i3c_i2c_device_desc *i3c_i2c_desc;
 
 	/* check to see if the device has already been attached */
-	if (!sys_slist_is_empty(&data->attached_dev.devices.i2c)) {
-		SYS_SLIST_FOR_EACH_NODE(&data->attached_dev.devices.i2c, node) {
-			if (node == &target->node) {
+	I3C_BUS_FOR_EACH_I2CDEV(target->bus, i3c_i2c_desc) {
+		if (i3c_i2c_desc == target) {
 				return -EINVAL;
 			}
 		}
-	}
 
 	if (!i3c_addr_slots_is_free(&data->attached_dev.addr_slots, target->addr)) {
 		return -EINVAL;
@@ -448,8 +404,7 @@ int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
 		 */
 		ret = -ENODEV;
 
-		LOG_DBG("PID 0x%04x%08x is not in registered device list",
-			vendor_id, part_no);
+		LOG_DBG("PID 0x%04x%08x is not in registered device list", vendor_id, part_no);
 
 		goto out;
 	}
@@ -506,35 +461,36 @@ err:
 int i3c_device_basic_info_get(struct i3c_device_desc *target)
 {
 	int ret;
-	uint8_t tmp_bcr;
-
 	struct i3c_ccc_getbcr bcr = {0};
 	struct i3c_ccc_getdcr dcr = {0};
-	struct i3c_ccc_mrl mrl = {0};
-	struct i3c_ccc_mwl mwl = {0};
-	union i3c_ccc_getcaps caps = {0};
-
-	/*
-	 * Since some CCC functions requires BCR to function
-	 * correctly, we save the BCR here and update the BCR
-	 * in the descriptor. If any following operations fails,
-	 * we can restore the BCR.
-	 */
-	tmp_bcr = target->bcr;
 
 	/* GETBCR */
 	ret = i3c_ccc_do_getbcr(target, &bcr);
 	if (ret != 0) {
-		goto out;
+		return ret;
 	}
-
-	target->bcr = bcr.bcr;
 
 	/* GETDCR */
 	ret = i3c_ccc_do_getdcr(target, &dcr);
 	if (ret != 0) {
-		goto out;
+		return ret;
 	}
+
+	target->bcr = bcr.bcr;
+	target->dcr = dcr.dcr;
+
+	return 0;
+	}
+
+int i3c_device_adv_info_get(struct i3c_device_desc *target)
+{
+	struct i3c_ccc_mrl mrl = {0};
+	struct i3c_ccc_mwl mwl = {0};
+	union i3c_ccc_getcaps caps = {0};
+	union i3c_ccc_getmxds mxds = {0};
+	int ret;
+
+	LOG_DBG("func: %s [%p]", __func__, (void *)&i3c_device_adv_info_get);
 
 	/* GETMRL */
 	if (i3c_ccc_do_getmrl(target, &mrl) != 0) {
@@ -550,6 +506,7 @@ int i3c_device_basic_info_get(struct i3c_device_desc *target)
 
 	/* GETCAPS */
 	ret = i3c_ccc_do_getcaps_fmt1(target, &caps);
+	LOG_DBG("GETCAPS ret (%d)", ret);
 	/*
 	 * GETCAPS (GETHDRCAP) is required to be supported for I3C v1.0 targets that support HDR
 	 * modes and required if the Target's I3C version is v1.1 or later, but which the version it
@@ -557,22 +514,34 @@ int i3c_device_basic_info_get(struct i3c_device_desc *target)
 	 * set, then it is expected for GETCAPS to always be supported. Otherwise, then it's a I3C
 	 * v1.0 device without any HDR modes so do not treat as an error if no valid response.
 	 */
-	if (ret == 0) {
-		memcpy(&target->getcaps, &caps, sizeof(target->getcaps));
-	} else if ((ret != 0) && (target->bcr & I3C_BCR_ADV_CAPABILITIES)) {
-		goto out;
+	if ((ret != 0) && (target->bcr & I3C_BCR_ADV_CAPABILITIES)) {
+		return ret;
+	} else {
+		ret = 0;
 	}
 
-	target->dcr = dcr.dcr;
+	/* GETMXDS */
+	if (target->bcr & I3C_BCR_MAX_DATA_SPEED_LIMIT) {
+		ret = i3c_ccc_do_getmxds_fmt2(target, &mxds);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	LOG_DBG("target->getcaps ptr %p size %d", (void *)&target->getcaps,
+		sizeof(target->getcaps));
+
+	/* Some values may not have been read, but set them back to 0 */
+	memcpy(&target->getcaps, &caps, sizeof(target->getcaps));
+
+	target->data_speed.maxrd = mxds.fmt2.maxrd;
+	target->data_speed.maxwr = mxds.fmt2.maxwr;
+	target->data_speed.max_read_turnaround = sys_get_le24(mxds.fmt2.maxrdturn);
+
 	target->data_length.mrl = mrl.len;
 	target->data_length.mwl = mwl.len;
 	target->data_length.max_ibi = mrl.ibi_len;
 
-out:
-	if (ret != 0) {
-		/* Restore BCR is any CCC fails. */
-		target->bcr = tmp_bcr;
-	}
 	return ret;
 }
 
@@ -587,15 +556,18 @@ out:
  */
 static int i3c_bus_setdasa(const struct device *dev,
 			   const struct i3c_dev_list *dev_list,
-			   bool *need_daa)
+			   bool *need_daa, bool *need_aasa)
 {
 	int i, ret;
 
 	*need_daa = false;
+	*need_aasa = false;
 
 	/* Loop through the registered I3C devices */
 	for (i = 0; i < dev_list->num_i3c; i++) {
 		struct i3c_device_desc *desc = &dev_list->i3c[i];
+		struct i3c_driver_data *bus_data = (struct i3c_driver_data *)dev->data;
+		struct i3c_ccc_address dyn_addr;
 
 		/*
 		 * A device without static address => need to do
@@ -606,12 +578,44 @@ static int i3c_bus_setdasa(const struct device *dev,
 			continue;
 		}
 
+		/*
+		 * A device that supports SETAASA and will use the same dynamic
+		 * address as its static address if a different dynamic address
+		 * is not requested
+		 */
+		if ((desc->supports_setaasa) && ((desc->init_dynamic_addr == 0) ||
+					       desc->init_dynamic_addr == desc->static_addr)) {
+			*need_aasa = true;
+			continue;
+		}
+
 		LOG_DBG("SETDASA for 0x%x", desc->static_addr);
 
-		ret = i3c_ccc_do_setdasa(desc);
+		/*
+		 * check that initial dynamic address is free before setting it
+		 * if configured
+		 */
+		if ((desc->init_dynamic_addr != 0) &&
+			(desc->init_dynamic_addr != desc->static_addr)) {
+			if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots,
+				desc->init_dynamic_addr)) {
+				if (i3c_detach_i3c_device(desc) != 0) {
+					LOG_ERR("Failed to detach %s", desc->dev->name);
+				}
+				continue;
+			}
+		}
+
+		/*
+		 * Note that the 7-bit address needs to start at bit 1
+		 * (aka left-justified). So shift left by 1;
+		 */
+		dyn_addr.addr = (desc->init_dynamic_addr ?
+					desc->init_dynamic_addr : desc->static_addr) << 1;
+
+		ret = i3c_ccc_do_setdasa(desc, dyn_addr);
 		if (ret == 0) {
-			desc->dynamic_addr = (desc->init_dynamic_addr ? desc->init_dynamic_addr
-								      : desc->static_addr);
+			desc->dynamic_addr = dyn_addr.addr >> 1;
 			if (desc->dynamic_addr != desc->static_addr) {
 				if (i3c_reattach_i3c_device(desc, desc->static_addr) != 0) {
 					LOG_ERR("Failed to reattach %s (%d)", desc->dev->name, ret);
@@ -624,19 +628,109 @@ static int i3c_bus_setdasa(const struct device *dev,
 			}
 			LOG_ERR("SETDASA error on address 0x%x (%d)",
 				desc->static_addr, ret);
-			continue;
 		}
 	}
 
 	return 0;
 }
 
+bool i3c_bus_has_sec_controller(const struct device *dev)
+{
+	struct i3c_device_desc *i3c_desc;
+
+	LOG_DBG("sec_controller check");
+
+	I3C_BUS_FOR_EACH_I3CDEV(dev, i3c_desc) {
+		if (i3c_device_is_controller_capable(i3c_desc)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int i3c_bus_deftgts(const struct device *dev)
+{
+	struct i3c_driver_data *data = (struct i3c_driver_data *)dev->data;
+	struct i3c_config_target config_target;
+	struct i3c_ccc_deftgts *deftgts;
+	struct i3c_device_desc *i3c_desc;
+	struct i3c_i2c_device_desc *i3c_i2c_desc;
+	int ret;
+	uint8_t n = 0;
+	size_t num_of_targets = sys_slist_len(&data->attached_dev.devices.i3c) +
+				sys_slist_len(&data->attached_dev.devices.i2c);
+	size_t data_len = sizeof(uint8_t) +
+				   sizeof(struct i3c_ccc_deftgts_active_controller) +
+				   (num_of_targets * sizeof(struct i3c_ccc_deftgts_target));
+
+	/*
+	 * Retrieve the active controller information
+	 */
+	ret = i3c_config_get(dev, I3C_CONFIG_TARGET, &config_target);
+	if (ret != 0) {
+		LOG_ERR("Failed to retrieve active controller info");
+		return ret;
+	}
+
+	/* Allocate memory for the struct with enough space for the targets */
+	deftgts = malloc(data_len);
+	if (!deftgts) {
+		return -ENOMEM;
+	}
+
+	/*
+	 * Write the total number of I3C and I2C targets to the payload
+	 */
+	deftgts->count = num_of_targets;
+
+	/*
+	 * Add the active controller information to the payload
+	 */
+	deftgts->active_controller.addr = config_target.dynamic_addr << 1;
+	deftgts->active_controller.dcr = config_target.dcr;
+	deftgts->active_controller.bcr = config_target.bcr;
+	deftgts->active_controller.static_addr = I3C_BROADCAST_ADDR << 1;
+
+	/*
+	 * Loop through each attached I3C device and add it to the payload
+	 */
+	I3C_BUS_FOR_EACH_I3CDEV(dev, i3c_desc) {
+		deftgts->targets[n].addr = i3c_desc->dynamic_addr << 1;
+		deftgts->targets[n].dcr = i3c_desc->dcr;
+		deftgts->targets[n].bcr = i3c_desc->bcr;
+		deftgts->targets[n].static_addr = i3c_desc->static_addr << 1;
+		n++;
+	}
+
+	/*
+	 * Loop through each attached I2C device and add it to the payload
+	 */
+	I3C_BUS_FOR_EACH_I2CDEV(dev, i3c_i2c_desc) {
+		deftgts->targets[n].addr = 0;
+		deftgts->targets[n].lvr = i3c_i2c_desc->lvr;
+		deftgts->targets[n].bcr = 0;
+		deftgts->targets[n].static_addr = (uint8_t)(i3c_i2c_desc->addr << 1);
+		n++;
+	}
+
+	/* TODO: add support for Group Addr in DEFTGTS when that comes */
+
+	ret = i3c_ccc_do_deftgts_all(dev, deftgts);
+
+	free(deftgts);
+
+	return ret;
+}
+
 int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 {
 	int i, ret = 0;
 	bool need_daa = true;
+	bool need_aasa = true;
 	struct i3c_ccc_events i3c_events;
 
+#ifdef CONFIG_I3C_INIT_RSTACT
 	/*
 	 * Reset all connected targets. Also reset dynamic
 	 * addresses for all devices as we have no idea what
@@ -659,6 +753,7 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 			LOG_DBG("Broadcast RSTACT (peripehral) was NACK.");
 		}
 	}
+#endif
 
 	if (i3c_ccc_do_rstdaa_all(dev) != 0) {
 		LOG_DBG("Broadcast RSTDAA was NACK.");
@@ -678,15 +773,42 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 	/*
 	 * Set static addresses as dynamic addresses.
 	 */
-	ret = i3c_bus_setdasa(dev, dev_list, &need_daa);
+	ret = i3c_bus_setdasa(dev, dev_list, &need_daa, &need_aasa);
 	if (ret != 0) {
 		goto err_out;
+	}
+
+	/*
+	 * Perform Set All Addresses to Static Address if possible.
+	 */
+	if (need_aasa) {
+
+		LOG_DBG("SETAASA for all devices");
+
+		ret = i3c_ccc_do_setaasa_all(dev);
+		if (ret != 0) {
+			for (i = 0; i < dev_list->num_i3c; i++) {
+				struct i3c_device_desc *desc = &dev_list->i3c[i];
+				/*
+				 * Only set for devices that support SETAASA and do not
+				 * request a different dynamic address than its SA
+				 */
+				if ((desc->supports_setaasa) && (desc->static_addr != 0) &&
+				    ((desc->init_dynamic_addr == 0) ||
+				     desc->init_dynamic_addr == desc->static_addr)) {
+					desc->dynamic_addr = desc->static_addr;
+				}
+			}
+		}
 	}
 
 	/*
 	 * Perform Dynamic Address Assignment if needed.
 	 */
 	if (need_daa) {
+
+		LOG_DBG("DAA for all devices");
+
 		ret = i3c_do_daa(dev);
 		if (ret != 0) {
 			/*
@@ -713,19 +835,44 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 	for (i = 0; i < dev_list->num_i3c; i++) {
 		struct i3c_device_desc *desc = &dev_list->i3c[i];
 
+		LOG_DBG("i3c_device_desc ptr: %p", desc);
+
 		if (desc->dynamic_addr == 0U) {
+
+			LOG_DBG("i3c[%d] has no dynamic address", i);
+
 			continue;
 		}
 
-		ret = i3c_device_basic_info_get(desc);
+		LOG_DBG("=i3c_device_desc ptr: %p=", desc);
+
+		/*
+		 * If static address is 0, then it is assumed that BCR
+		 * and DCR were already read through ENTDAA
+		 */
+		ret = (desc->static_addr == 0) ? i3c_device_adv_info_get(desc)
+					       : i3c_device_info_get(desc);
+
+		LOG_DBG("i3c_device_adv_info_get ret (%d)", ret);
+
 		if (ret != 0) {
-			LOG_ERR("Error getting basic device info for 0x%02x",
+			LOG_ERR("Error getting device info for 0x%02x",
 				desc->static_addr);
 		} else {
 			LOG_DBG("Target 0x%02x, BCR 0x%02x, DCR 0x%02x, MRL %d, MWL %d, IBI %d",
 				desc->dynamic_addr, desc->bcr, desc->dcr,
 				desc->data_length.mrl, desc->data_length.mwl,
 				desc->data_length.max_ibi);
+		}
+	}
+
+	if (i3c_bus_has_sec_controller(dev)) {
+
+		LOG_DBG("Secondary controller detected");
+
+		ret = i3c_bus_deftgts(dev);
+		if (ret != 0) {
+			LOG_ERR("Error sending DEFTGTS");
 		}
 	}
 
@@ -736,10 +883,15 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 	 * enable the event.
 	 */
 	i3c_events.events = I3C_CCC_EVT_HJ;
+
+	LOG_DBG("i3c_events ptr: %p", &i3c_events);
+
 	ret = i3c_ccc_do_events_all_set(dev, true, &i3c_events);
 	if (ret != 0) {
 		LOG_DBG("Broadcast ENEC was NACK.");
 	}
+
+	LOG_DBG("I3C bus initialization done");
 
 err_out:
 	return ret;

--- a/drivers/i3c/i3c_handlers.c
+++ b/drivers/i3c/i3c_handlers.c
@@ -35,7 +35,7 @@ static inline int z_vrfy_i3c_do_ccc(const struct device *dev,
 
 	return z_impl_i3c_do_ccc(dev, payload);
 }
-#include <syscalls/i3c_do_ccc_mrsh.c>
+#include <zephyr/syscalls/i3c_do_ccc_mrsh.c>
 
 static uint32_t copy_i3c_msgs_and_transfer(struct i3c_device_desc *target,
 					   const struct i3c_msg *msgs,
@@ -79,4 +79,4 @@ static inline int z_vrfy_i3c_transfer(struct i3c_device_desc *target,
 					  (struct i3c_msg *)msgs,
 					  (uint8_t)num_msgs);
 }
-#include <syscalls/i3c_transfer_mrsh.c>
+#include <zephyr/syscalls/i3c_transfer_mrsh.c>

--- a/drivers/i3c/i3c_ibi_workq.c
+++ b/drivers/i3c/i3c_ibi_workq.c
@@ -178,6 +178,13 @@ static void i3c_ibi_work_handler(struct k_work *work)
 		if ((ret != 0) && (ret != -EBUSY)) {
 			LOG_ERR("i3c_do_daa returns %d", ret);
 		}
+
+		if (i3c_bus_has_sec_controller(ibi_node->controller)) {
+			ret = i3c_bus_deftgts(ibi_node->controller);
+			if (ret != 0) {
+				LOG_ERR("Error sending DEFTGTS");
+			}
+		}
 		break;
 
 	case I3C_IBI_WORKQUEUE_CB:

--- a/drivers/i3c/i3c_nct.c
+++ b/drivers/i3c/i3c_nct.c
@@ -6,134 +6,142 @@
 
 #define DT_DRV_COMPAT nuvoton_nct_i3c
 
-#include <string.h>
-
-#include <zephyr/device.h>
-#include <zephyr/irq.h>
-#include <zephyr/sys/__assert.h>
-#include <zephyr/sys/sys_io.h>
-
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/i3c.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <stdlib.h>
+#include "i3c_nct.h"
+
+#include <zephyr/drivers/gpio.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(nct_i3c, CONFIG_I3C_LOG_LEVEL);
 
-#define NCT_I3C_CHK_TIMEOUT_US 10000 /* Timeout for checking register status */
+/* I3C properties */
+#define I3C_CHK_TIMEOUT_US       10000 /* Timeout for checking register status */
+#define I3C_CLK_FREQ_48_MHZ      MHZ(48)
+#define I3C_CLK_FREQ_96_MHZ      MHZ(96)
 #define I3C_SCL_PP_FREQ_MAX_MHZ 12500000
 #define I3C_SCL_OD_FREQ_MAX_MHZ 4170000
-
 #define I3C_BUS_TLOW_PP_MIN_NS  24  /* T_LOW period in push-pull mode */
 #define I3C_BUS_TLOW_OD_MIN_NS  200 /* T_LOW period in open-drain mode */
-
-#define PPBAUD_DIV_MAX (BIT(GET_FIELD_SZ(NCT_I3C_MCONFIG_PPBAUD)) - 1) /* PPBAUD divider max */
-#define I2CBAUD_DIV_MAX (BIT(GET_FIELD_SZ(NCT_I3C_MCONFIG_I2CBAUD)) - 1) /* I2C divider max */
-
+#define I3C_TGT_WR_REQ_WAIT_US   10  /* I3C target write request PDMA completion after stop */
+#define I3C_FIFO_SIZE            16
+#define PPBAUD_DIV_MAX           0xF
+#define I2CBAUD_DIV_MAX          0xF
 #define DAA_TGT_INFO_SZ 0x8 /* 8 bytes = PID(6) + BCR(1) + DCR(1) */
-
-/* Default maximum time we allow for an I3C transfer */
-#define I3C_TRANS_TIMEOUT_MS K_MSEC(100)
-
-#define I3C_CLK_FREQ_48_MHZ MHZ(48)
-#define I3C_CLK_FREQ_96_MHZ MHZ(96)
-
+#define I3C_TRANS_TIMEOUT_MS     K_MSEC(1000) /*  Default maximum allow time for an I3C transfer */
+#define I3C_IBI_MAX_PAYLOAD_SIZE 32
 #define I3C_STATUS_CLR_MASK                                                 \
-	(BIT(NCT_I3C_MSTATUS_TGTSTART) | BIT(NCT_I3C_MSTATUS_MCTRLDONE) | \
-	 BIT(NCT_I3C_MSTATUS_COMPLETE) | BIT(NCT_I3C_MSTATUS_IBIWON) |    \
-	 BIT(NCT_I3C_MSTATUS_NOWCNTLR))
+	(BIT(NCT_I3C_MSTATUS_TGTSTART) | BIT(NCT_I3C_MSTATUS_MCTRLDONE) | BIT(NCT_I3C_MSTATUS_COMPLETE) |      \
+	 BIT(NCT_I3C_MSTATUS_IBIWON) | BIT(NCT_I3C_MSTATUS_NOWCNTLR))
 
+#define I3C_TGT_INTSET_MASK                                                                        \
+	(BIT(NCT_I3C_INTSET_START) | BIT(NCT_I3C_INTSET_MATCHED) | BIT(NCT_I3C_INTSET_STOP) |                  \
+	 BIT(NCT_I3C_INTSET_DACHG) | BIT(NCT_I3C_INTSET_CCC) | BIT(NCT_I3C_INTSET_ERRWARN) |                   \
+	 BIT(NCT_I3C_INTSET_DDRMATCHED) | BIT(NCT_I3C_INTSET_CHANDLED) | BIT(NCT_I3C_INTSET_EVENT))
+
+/* Register access helper */
+
+/* Driver convenience defines */
+#define HAL_INSTANCE(dev) ((struct i3c_reg *)((const struct nct_i3c_config *)(dev)->config)->base)
+#define NCT_PCC_NODE     DT_NODELABEL(pcc)
+
+/* I3C hardware index parsing */
 #define I3C_NCT_HW_IDX(n) ((n & 0xFFF) >> 9)
 
+/* I3C target PID parsing */
+#define GET_PID_VENDOR_ID(pid) (((uint64_t)pid >> 33) & 0x7fff) /* PID[47:33] */
+#define GET_PID_ID_TYP(pid)    (((uint64_t)pid >> 32) & 0x1)    /* PID[32] */
+#define GET_PID_PARTNO(pid)    (pid & 0xffffffff)               /* PID[31:0] */
 #ifdef CONFIG_I3C_NCT_DMA
-#define I3C_NCT_PDMA_MUX_ID(n, rnw)	rnw ? ((((n & 0xFFF) >> 9) * 2) + 5) : \
-						((((n & 0xFFF) >> 9) * 2) + 6)
+/* PDMA mux ID parsing */
+#define I3C_NCT_PDMA_MUX_ID(n, rnw)                                                               \
+	(rnw ? ((((n & 0xFFF) >> 9) * 2) + 5) : ((((n & 0xFFF) >> 9) * 2) + 6))
 #endif
+
+/* PDMA channel parsing */
+#define NCT_PDMA_BASE(n)         (n & 0xFFFFFF00)
+#define NCT_PDMA_DSCT_IDX(n)     ((n - (n & 0xFFFFFF00)) >> 4)
+#define NCT_PDMA_CHANNEL_PER_REQ 0x4
 
 /* Supported I3C clock frequency */
 enum nct_i3c_clk_speed {
-	NCT_I3C_CLK_FREQ_48MHZ,
-	NCT_I3C_CLK_FREQ_96MHZ,
+	I3C_CLK_FREQ_48MHZ,
+	I3C_CLK_FREQ_96MHZ,
 };
 
-/* I3C timing configuration for each i3c/i2c speed */
-struct nct_i3c_timing_cfg {
-	uint8_t ppbaud;		/* Push-Pull high period */
-	uint8_t pplow;		/* Push-Pull low period */
-	uint8_t odhpp;		/* Open-Drain high period */
-	uint8_t odbaud;		/* Open-Drain low period */
-	uint8_t i2c_baud;	/* I2C period */
-};
-
-/* Recommended I3C timing values are based on I3C frequency 48 or 96 MHz */
 static const struct nct_i3c_timing_cfg nct_def_speed_cfg[] = {
-	/* PP = 12.5 mhz, OD = 4.17 Mhz, i2c = 1.0 Mhz */
-	[NCT_I3C_CLK_FREQ_48MHZ] = {.ppbaud = 1, .pplow = 0, .odhpp = 1, .odbaud = 4, .i2c_baud = 3},
-	[NCT_I3C_CLK_FREQ_96MHZ] = {.ppbaud = 3, .pplow = 0, .odhpp = 1, .odbaud = 4, .i2c_baud = 3},
-};
-
-struct nct_i3c_config {
-	/* Common I3C Driver Config */
-	struct i3c_driver_config common;
-
-	/* Pointer to controller registers. */
-	struct i3c_reg *base;
-
-	/* Clock configuration */
-	uint32_t clk_cfg;
-
-	/* Pointer to pin control device. */
-	const struct pinctrl_dev_config *pincfg;
-
-	/* Interrupt configuration function. */
-	void (*irq_config_func)(const struct device *dev);
-
-	struct {
-		uint32_t i3c_pp_scl_hz; /* I3C push pull clock frequency in Hz. */
-		uint32_t i3c_od_scl_hz; /* I3C open drain clock frequency in Hz. */
-		uint32_t i2c_scl_hz;	/* I2C clock frequency in Hz */
-	} clocks;
-
-#ifdef CONFIG_I3C_NCT_DMA
-	struct pdma_dsct_reg *pdma_rx;
-	struct pdma_dsct_reg *pdma_tx;
-#endif
-};
-
-struct nct_i3c_data {
-	struct i3c_driver_data common;       /* Common i3c driver data */
-	struct k_mutex lock_mutex;           /* Mutex of i3c controller */
-	struct k_sem sync_sem;               /* Semaphore used for synchronization */
-	struct k_sem ibi_lock_sem;           /* Semaphore used for ibi */
-
-#ifdef CONFIG_I3C_USE_IBI
-	struct {
-		/* List of addresses used in the MIBIRULES register. */
-		uint8_t addr[5];
-
-		/* Number of valid addresses in MIBIRULES. */
-		uint8_t num_addr;
-
-		/* True if all addresses have MSB set. */
-		bool msb;
-
 		/*
-		 * True if all target devices require mandatory byte
-		 * for IBI.
+	 * Recommended I3C timing values are based on I3C frequency 48 or 96 MHz
+	 * PP = 12.5 mhz, OD = 4.17 Mhz, i2c = 1.0 Mhz
 		 */
-		bool has_mandatory_byte;
-	} ibi;
-#endif
-
-#ifdef CONFIG_I3C_NCT_DMA
-	struct pdma_dsct_reg dsct_sg[2] __aligned(4);  /* use for dma, 4-bytes align */
-#endif
+	[I3C_CLK_FREQ_48MHZ] = {.ppbaud = 1, .pplow = 0, .odhpp = 1, .odbaud = 4, .i2c_baud = 3},
+	[I3C_CLK_FREQ_96MHZ] = {.ppbaud = 3, .pplow = 0, .odhpp = 1, .odbaud = 4, .i2c_baud = 3},
 };
 
-/* Driver convenience defines */
-#define HAL_INSTANCE(dev) \
-	((struct i3c_reg *)((const struct nct_i3c_config *)(dev)->config)->base)
+//============================================================
+void init_i3c_slave_rx_payload(const struct device *dev)
+{
+	struct nct_i3c_data *data = dev->data;
+	uint8_t i;
 
+	for (i = 0; i < ARRAY_SIZE(data->pdma_rx_buf); i++) {
+		data->slave_rx_payload[i].buf = &data->pdma_rx_buf[i][0];
+		data->slave_rx_payload[i].size = sizeof(data->pdma_rx_buf[i]);
+	}
+
+	data->rx_payload_curr = &data->slave_rx_payload[0];
+	data->rx_payload_in = 0;
+	data->rx_payload_out = 0;
+}
+
+struct i3c_slave_payload *alloc_i3c_slave_rx_payload(const struct device *dev)
+{
+	struct nct_i3c_data *data = dev->data;
+
+	return data->rx_payload_curr;
+}
+
+void update_i3c_slave_rx_payload(const struct device *dev)
+{
+	struct nct_i3c_data *data = dev->data;
+
+	data->rx_payload_in = (data->rx_payload_in + 1) % ARRAY_SIZE(data->pdma_rx_buf);
+	data->rx_payload_curr = &data->slave_rx_payload[data->rx_payload_in];
+
+	/* if queue full, skip the oldest un-read message */
+	if (data->rx_payload_in == data->rx_payload_out) {
+		data->rx_payload_out = (data->rx_payload_out + 1) % ARRAY_SIZE(data->pdma_rx_buf);
+	}
+}
+
+//==========================================================
+static K_SEM_DEFINE(tx_fifo_empty_sem, 0, 1);
+
+// used by ap layer to wait for tx fifo empty
+int target_wait_for_tx_fifo_empty(k_timeout_t timeout) {
+    if (k_sem_take(&tx_fifo_empty_sem, timeout) == 0) {
+        return 0;
+    } else {
+        return -ETIMEDOUT;
+    }
+}
+
+// used in i3c target isr to release semaphore
+static void tx_fifo_empty_handler(void) {
+    k_sem_give(&tx_fifo_empty_sem);
+}
+
+typedef void (*tx_fifo_empty_cb_t)(void);
+static tx_fifo_empty_cb_t tx_fifo_empty_cb = NULL;
+
+void target_register_tx_fifo_empty_cb(tx_fifo_empty_cb_t cb) {
+    tx_fifo_empty_cb = cb;
+}
+//============================================================
+
+/* I3C functions */
 static void nct_i3c_mutex_lock(const struct device *dev)
 {
 	struct nct_i3c_data *const data = dev->data;
@@ -151,7 +159,7 @@ static void nct_i3c_mutex_unlock(const struct device *dev)
 static void nct_i3c_reset_module(const struct device *dev)
 {
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
-	struct pmc_reg *pmc = (struct pmc_reg *)NCT_PMC_REG_ADDR;
+	struct pmc_reg *pmc = (struct pmc_reg *)DT_REG_ADDR_BY_NAME(NCT_PCC_NODE, pmc);
 	uint8_t index;
 
 	index = I3C_NCT_HW_IDX((uint32_t)i3c_inst);
@@ -171,14 +179,13 @@ static void nct_i3c_reset_module(const struct device *dev)
  * return  0, success
  *         -ETIMEDOUT: check status timeout.
  */
-static inline int nct_i3c_status_wait_clear(struct i3c_reg *i3c_inst, uint8_t bit_offset)
+static inline int nct_i3c_status_wait_clear(struct i3c_reg *i3c_inst, uint32_t bit_val)
 {
-	if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, bit_offset),
-				NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+	if (WAIT_FOR(i3c_inst->MSTATUS & bit_val, I3C_CHK_TIMEOUT_US, NULL) == false) {
 		return -ETIMEDOUT;
 	}
 
-	i3c_inst->MSTATUS = BIT(bit_offset); /* W1C */
+	i3c_inst->MSTATUS = bit_val; /* W1C */
 
 	return 0;
 }
@@ -200,12 +207,49 @@ static inline void nct_i3c_interrupt_enable(struct i3c_reg *i3c_inst, uint32_t m
 	i3c_inst->MINTSET = mask;
 }
 
+static void nct_i3c_enable_target_interrupt(const struct device *dev, bool enable)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+
+	/* Disable the target interrupt events */
+	i3c_inst->INTCLR = i3c_inst->INTSET;
+
+	/* Clear the target interrupt status */
+	i3c_inst->STATUS = i3c_inst->STATUS;
+
+	/* Enable the target interrupt events */
+	if (enable) {
+		i3c_inst->INTSET = I3C_TGT_INTSET_MASK;
+		i3c_inst->MINTSET |= BIT(NCT_I3C_MINTSET_NOWMASTER); /* I3C target is now controller */
+
+#ifndef CONFIG_I3C_NCT_DMA
+		/* Receive buffer pending (FIFO mode) */
+		i3c_inst->INTSET |= BIT(NCT_I3C_INTSET_RXPEND);
+#endif
+	}
+}
+
+static inline void nct_i3c_target_rx_fifo_flush(struct i3c_reg *i3c_inst)
+{
+	i3c_inst->DATACTRL |= BIT(NCT_I3C_DATACTRL_FLUSHFB);
+}
+
+static inline void nct_i3c_target_tx_fifo_flush(struct i3c_reg *i3c_inst)
+{
+	i3c_inst->DATACTRL |= BIT(NCT_I3C_DATACTRL_FLUSHTB);
+}
+
 static bool nct_i3c_has_error(struct i3c_reg *i3c_inst)
 {
 	if (IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_ERRWARN)) {
+		if (i3c_inst->MERRWARN == BIT(NCT_I3C_MERRWARN_TIMEOUT)) {
+			LOG_DBG("Timeout error, MERRWARN 0x%08x", i3c_inst->MERRWARN);
+			i3c_inst->MERRWARN = BIT(NCT_I3C_MERRWARN_TIMEOUT);
+			return false;
+		}
+
 		LOG_WRN("ERROR: MSTATUS 0x%08x MERRWARN 0x%08x", i3c_inst->MSTATUS,
 							i3c_inst->MERRWARN);
-
 		return true;
 	}
 
@@ -216,15 +260,22 @@ static inline void nct_i3c_status_clear_all(struct i3c_reg *i3c_inst)
 {
 	uint32_t mask = I3C_STATUS_CLR_MASK;
 
+	// don't clear SLVSTART
+	if (IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_TGTSTART)) {
+		mask &= ~BIT(NCT_I3C_MSTATUS_TGTSTART);		
+	}
+
 	i3c_inst->MSTATUS = mask;
 }
 
 static inline void nct_i3c_errwarn_clear_all(struct i3c_reg *i3c_inst)
 {
+	if (i3c_inst->MERRWARN) {
 	i3c_inst->MERRWARN = i3c_inst->MERRWARN;
 }
+}
 
-static inline void nct_i3c_fifo_flush(struct i3c_reg *i3c_inst)
+static inline void nct_i3c_controller_fifo_flush(struct i3c_reg *i3c_inst)
 {
 	i3c_inst->MDATACTRL |= (BIT(NCT_I3C_MDATACTRL_FLUSHTB) | BIT(NCT_I3C_MDATACTRL_FLUSHFB));
 }
@@ -242,7 +293,7 @@ static inline int nct_i3c_send_request(struct i3c_reg *i3c_inst, uint32_t mctrl_
 {
 	i3c_inst->MCTRL = mctrl_val;
 
-	if (nct_i3c_status_wait_clear(i3c_inst, NCT_I3C_MSTATUS_MCTRLDONE) != 0) {
+	if (nct_i3c_status_wait_clear(i3c_inst, BIT(NCT_I3C_MSTATUS_MCTRLDONE)) != 0) {
 		return -ETIMEDOUT;
 	}
 
@@ -300,15 +351,14 @@ static inline int nct_i3c_request_auto_ibi(struct i3c_reg *i3c_inst)
  * param[in] i3c_inst     Pointer to I3C register.
  * param[in] addr     Dyamic address for xfer or 0x7E for CCC command.
  * param[in] op_type  Request type.
- * param[in] is_read  Read(true) or write(false) operation.
+ * param[in] is_rx    true=rx or false=tx operation.
  * param[in] read_sz  Read size.
  *
  * return  0, success
  *         else, error
  */
 static int nct_i3c_request_emit_start(struct i3c_reg *i3c_inst, uint8_t addr,
-				       enum nct_i3c_mctrl_type op_type, bool is_read,
-				       size_t read_sz)
+				       enum nct_i3c_mctrl_type op_type, bool is_rx, size_t read_sz)
 {
 	uint32_t mctrl = 0;
 	int ret;
@@ -325,10 +375,12 @@ static int nct_i3c_request_emit_start(struct i3c_reg *i3c_inst, uint8_t addr,
 	/* Set dynamic address */
 	SET_FIELD(mctrl, NCT_I3C_MCTRL_ADDR, addr);
 
-	/* Set read(1) or write(0) */
-	if (is_read) {
+	/* Set rx or tx */
+	if (is_rx) {
 		mctrl |= BIT(NCT_I3C_MCTRL_DIR);
+		if (read_sz <= 255) {
 		SET_FIELD(mctrl, NCT_I3C_MCTRL_RDTERM, read_sz); /* Set read length */
+		}
 	} else {
 		mctrl &= ~BIT(NCT_I3C_MCTRL_DIR);
 	}
@@ -367,7 +419,8 @@ static inline int nct_i3c_request_emit_stop(struct i3c_reg *i3c_inst)
 	uint32_t i3c_state = nct_i3c_state_get(i3c_inst);
 
 	/* Make sure we are in a state where we can emit STOP */
-	if (i3c_state == MSTATUS_STATE_IDLE || i3c_state == MSTATUS_STATE_TGTREQ) {
+	if (i3c_state == MSTATUS_STATE_IDLE ||
+	    i3c_state == MSTATUS_STATE_TGTREQ) {
 		LOG_ERR("Request stop state error, state= %#x", i3c_state);
 		return -ECANCELED;
 	}
@@ -461,15 +514,15 @@ static int nct_i3c_recover_bus(const struct device *dev)
 		/* Tell the controller to perform auto IBI. */
 		nct_i3c_request_auto_ibi(i3c_inst);
 
-		if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE),
-			     NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+		if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE), I3C_CHK_TIMEOUT_US,
+			     NULL) == false) {
 			break;
 		}
 
 		/* Once auto IBI is done, discard bytes in FIFO. */
 		while (IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_RXPEND)) {
 			/* Flush FIFO as long as RXPEND is set. */
-			nct_i3c_fifo_flush(i3c_inst);
+			nct_i3c_controller_fifo_flush(i3c_inst);
 		}
 
 		/* Emit stop */
@@ -485,7 +538,7 @@ static int nct_i3c_recover_bus(const struct device *dev)
 
 	/* Check IDLE state */
 	if (WAIT_FOR((nct_i3c_state_get(i3c_inst) == MSTATUS_STATE_IDLE),
-				NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+		     I3C_CHK_TIMEOUT_US, NULL) == false) {
 		return -EBUSY;
 	}
 
@@ -496,7 +549,7 @@ static inline void nct_i3c_xfer_reset(struct i3c_reg *i3c_inst)
 {
 	nct_i3c_status_clear_all(i3c_inst);
 	nct_i3c_errwarn_clear_all(i3c_inst);
-	nct_i3c_fifo_flush(i3c_inst);
+	nct_i3c_controller_fifo_flush(i3c_inst);
 }
 
 /*
@@ -521,8 +574,8 @@ static int nct_i3c_xfer_write_fifo(struct i3c_reg *i3c_inst, uint8_t *buf, uint8
 
 	while (remaining > 0) {
 		/* Check tx fifo not full */
-		if (WAIT_FOR(!IS_BIT_SET(i3c_inst->MDATACTRL, NCT_I3C_MDATACTRL_TXFULL),
-			     NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+		if (WAIT_FOR(!(IS_BIT_SET(i3c_inst->MDATACTRL, NCT_I3C_MDATACTRL_TXFULL)), 
+				I3C_CHK_TIMEOUT_US, NULL) == false) {
 			LOG_DBG("Check tx fifo not full timed out");
 			return -ETIMEDOUT;
 		}
@@ -584,7 +637,8 @@ static int nct_i3c_xfer_read_fifo(struct i3c_reg *i3c_inst, uint8_t *buf, uint8_
 			 * FIFO data when the i3c speed is high.
 			 */
 			while (offset < rd_sz) {
-				if (GET_FIELD(i3c_inst->MDATACTRL, NCT_I3C_MDATACTRL_RXCOUNT) == 0) {
+				if (GET_FIELD(i3c_inst->MDATACTRL,
+						       NCT_I3C_MDATACTRL_RXCOUNT) == 0) {
 					break;
 				}
 
@@ -596,13 +650,27 @@ static int nct_i3c_xfer_read_fifo(struct i3c_reg *i3c_inst, uint8_t *buf, uint8_
 	return offset;
 }
 
+static enum nct_i3c_oper_state get_oper_state(const struct device *dev)
+{
+	struct nct_i3c_data *const data = dev->data;
+
+	return data->oper_state;
+}
+
+static void set_oper_state(const struct device *dev, enum nct_i3c_oper_state state)
+{
+	struct nct_i3c_data *const data = dev->data;
+
+	data->oper_state = state;
+}
+
 #ifdef CONFIG_I3C_NCT_DMA
-static int nct_i3c_pdma_dsct(const struct device *dev, bool is_read,
+static int nct_i3c_pdma_dsct(const struct device *dev, bool is_rx,
 			     struct pdma_dsct_reg **dsct_inst)
 {
 	const struct nct_i3c_config *config = dev->config;
 
-	if (is_read) {
+	if (is_rx) {
 		*dsct_inst = (struct pdma_dsct_reg *)config->pdma_rx;
 	} else {
 		*dsct_inst = (struct pdma_dsct_reg *)config->pdma_tx;
@@ -625,15 +693,15 @@ static int nct_i3c_ctrl_wait_completion(const struct device *dev)
 	return k_sem_take(&data->sync_sem, I3C_TRANS_TIMEOUT_MS);
 }
 
-static int nct_i3c_pdma_wait_completion(const struct device *dev, bool is_read)
+static int nct_i3c_pdma_wait_completion(const struct device *dev, bool is_rx)
 {
 	struct pdma_reg *pdma_inst;
 	struct pdma_dsct_reg *dsct_inst = NULL;
 	uint8_t dsct_idx;
 
-	dsct_idx = nct_i3c_pdma_dsct(dev, is_read, &dsct_inst);
+	dsct_idx = nct_i3c_pdma_dsct(dev, is_rx, &dsct_inst);
 	if (dsct_inst == NULL) {
-		LOG_ERR("dsct(%d) not exist", is_read);
+		LOG_ERR("dsct(%d) not exist", dsct_idx);
 		return -EINVAL;
 	}
 
@@ -644,8 +712,8 @@ static int nct_i3c_pdma_wait_completion(const struct device *dev, bool is_read)
 	}
 
 	/* Check dma transfer done */
-	if (WAIT_FOR(IS_BIT_SET(pdma_inst->PDMA_TDSTS, dsct_idx),
-				NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+	if (WAIT_FOR(IS_BIT_SET(pdma_inst->PDMA_TDSTS, dsct_idx), I3C_CHK_TIMEOUT_US, NULL) ==
+	    false) {
 		LOG_ERR("Check dma transfer done timed out");
 		return -ETIMEDOUT;
 	}
@@ -653,15 +721,15 @@ static int nct_i3c_pdma_wait_completion(const struct device *dev, bool is_read)
 	return 0;
 }
 
-static int nct_i3c_pdma_remain_count(const struct device *dev, bool is_read)
+static int nct_i3c_pdma_remain_count(const struct device *dev, bool is_rx)
 {
 	struct pdma_reg *pdma_inst;
 	struct pdma_dsct_reg *dsct_inst = NULL;
 	uint8_t dsct_idx;
 
-	dsct_idx = nct_i3c_pdma_dsct(dev, is_read, &dsct_inst);
+	dsct_idx = nct_i3c_pdma_dsct(dev, is_rx, &dsct_inst);
 	if (dsct_inst == NULL) {
-		LOG_ERR("dsct(%d) not exist", is_read);
+		LOG_ERR("dsct(%d) not exist", is_rx);
 		return -EINVAL;
 	}
 
@@ -678,16 +746,17 @@ static int nct_i3c_pdma_remain_count(const struct device *dev, bool is_read)
 	}
 }
 
-static int nct_i3c_pdma_stop(const struct device *dev, bool is_read)
+static int nct_i3c_pdma_stop(const struct device *dev, bool is_rx)
 {
+	struct nct_i3c_data *const data = dev->data;
 	struct pdma_dsct_reg *dsct_inst = NULL;
 	struct pdma_reg *pdma_inst;
 	uint8_t dsct_idx;
 	uint32_t key;
 
-	dsct_idx = nct_i3c_pdma_dsct(dev, is_read, &dsct_inst);
+	dsct_idx = nct_i3c_pdma_dsct(dev, is_rx, &dsct_inst);
 	if (dsct_inst == NULL) {
-		LOG_ERR("dsct(%d) not exist", is_read);
+		LOG_ERR("dsct(%d) not exist", is_rx);
 		return -EINVAL;
 	}
 
@@ -702,26 +771,30 @@ static int nct_i3c_pdma_stop(const struct device *dev, bool is_read)
 
 	/* Clear transfer done flag */
 	if (pdma_inst->PDMA_TDSTS & BIT(dsct_idx)) {
-		pdma_inst->PDMA_TDSTS |= BIT(dsct_idx);
+//		pdma_inst->PDMA_TDSTS |= BIT(dsct_idx);
 	}
 
 	pdma_inst->PDMA_CHCTL &= ~BIT(dsct_idx);
+
+	/* Clear DMA triggered flag */
+	data->dma_triggered &= ~BIT(dsct_idx);
 
 	irq_unlock(key);
 
 	return 0;
 }
 
-static int nct_i3c_pdma_start(const struct device *dev, bool is_read)
+static int nct_i3c_pdma_start(const struct device *dev, bool is_rx)
 {
+	struct nct_i3c_data *const data = dev->data;
 	struct pdma_dsct_reg *dsct_inst = NULL;
 	struct pdma_reg *pdma_inst;
 	uint8_t dsct_idx;
 	uint32_t key;
 
-	dsct_idx = nct_i3c_pdma_dsct(dev, is_read, &dsct_inst);
+	dsct_idx = nct_i3c_pdma_dsct(dev, is_rx, &dsct_inst);
 	if (dsct_inst == NULL) {
-		LOG_ERR("dsct(%d) not exist", is_read);
+		LOG_ERR("dsct(%d) not exist", is_rx);
 		return -EINVAL;
 	}
 
@@ -734,12 +807,19 @@ static int nct_i3c_pdma_start(const struct device *dev, bool is_read)
 
 	key = irq_lock();
 
+// disable pdma interrupt
+pdma_inst->PDMA_INTEN &= ~BIT(dsct_idx);
+
 	/* Clear transfer done flag */
 	if (pdma_inst->PDMA_TDSTS & BIT(dsct_idx)) {
 		pdma_inst->PDMA_TDSTS |= BIT(dsct_idx);
 	}
 
+	/* Start PDMA */
 	pdma_inst->PDMA_CHCTL |= BIT(dsct_idx);
+
+	/* Set DMA triggered flag */
+	data->dma_triggered |= BIT(dsct_idx);
 
 	irq_unlock(key);
 
@@ -754,7 +834,7 @@ static int nct_i3c_pdma_start(const struct device *dev, bool is_read)
  *
  * param[in] dev           Pointer to controller device driver instance.
  * param[in] type          i3c config type
- * param[in] rnw           read or write request.
+ * param[in] is_rx         true=rx or false=tx operation.
  * param[in] buf           Buffer to store data.
  * param[in] buf_sz        Number of bytes to read.
  * param[in] no_ending     True if not to signal end of message.
@@ -762,11 +842,11 @@ static int nct_i3c_pdma_start(const struct device *dev, bool is_read)
  * return  Successful return 0, or negative if error.
  *
  */
-static int nct_i3c_pdma_configure(const struct device *dev, enum i3c_config_type type,
-		                  bool is_read, uint8_t *buf, uint8_t buf_sz, bool no_ending)
+static int nct_i3c_pdma_configure(const struct device *dev, enum i3c_config_type type, bool is_rx,
+				   uint8_t *buf, uint16_t buf_sz, bool no_ending)
 {
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
-	struct nct_i3c_data *data = dev->data;
+	struct nct_i3c_data *const data = dev->data;
 	struct pdma_reg *pdma_inst;
 	struct pdma_dsct_reg *dsct_inst = NULL;
 	uint8_t dsct_idx;
@@ -776,16 +856,14 @@ static int nct_i3c_pdma_configure(const struct device *dev, enum i3c_config_type
 	uint32_t ctrl;
 	uint32_t key;
 
-	ARG_UNUSED(type);
-
-	/* No data to be transferred */
-	if ((buf == NULL) || (buf_sz == 0)) {
+	/* No data to be transferred or wrong type */
+	if ((buf == NULL) || (buf_sz == 0) || (type == I3C_CONFIG_CUSTOM)) {
 		return 0;
 	}
 
-	dsct_idx = nct_i3c_pdma_dsct(dev, is_read, &dsct_inst);
+	dsct_idx = nct_i3c_pdma_dsct(dev, is_rx, &dsct_inst);
 	if (dsct_inst == NULL) {
-		LOG_ERR("dsct(%d) not exist", is_read);
+		LOG_ERR("dsct(%d) not exist", is_rx);
 		return -EINVAL;
 	}
 
@@ -796,16 +874,17 @@ static int nct_i3c_pdma_configure(const struct device *dev, enum i3c_config_type
 		return -EINVAL;
 	}
 
-	i3c_mux_id = I3C_NCT_PDMA_MUX_ID((uint32_t)i3c_inst, is_read);
+	i3c_mux_id = I3C_NCT_PDMA_MUX_ID((uint32_t)i3c_inst, is_rx);
 
 	key = irq_lock();
 
 	/* Setup channel request selection */
-	SET_FIELD(pdma_inst->PDMA_REQSEL[(dsct_idx / NCT_PDMA_CHANNEL_PER_REQ)],
+	SET_FIELD(pdma_inst->PDMA_REQSEL[dsct_idx / NCT_PDMA_CHANNEL_PER_REQ],
 			NCT_PDMA_REQSEL_CHANNEL(dsct_idx % NCT_PDMA_CHANNEL_PER_REQ),
 			i3c_mux_id);
 
-	/* PDMA support scatter-gather and basic mode, we use scatter-gather mode
+	/*
+	 * PDMA support scatter-gather and basic mode, we use scatter-gather mode
 	 * as default mode.
 	 */
 	ctrl = 0;
@@ -814,12 +893,14 @@ static int nct_i3c_pdma_configure(const struct device *dev, enum i3c_config_type
 	dsct_inst->CTL = NCT_PDMA_DSCT_CTL_OPMODE_SGM;
 	dsct_inst->SA = 0x0;
 	dsct_inst->DA = 0x0;
-	dsct_inst->NEXT = (uint32_t)&data->dsct_sg[0];
+	dsct_inst->NEXT = (is_rx) ? ((uint32_t)&data->dsct_sg[0]) & 0xFFFF
+				  : ((uint32_t)&data->dsct_sg[2]) & 0xFFFF;
 
 	/* Configure scatter-gather table base MSB address. */
-	pdma_inst->PDMA_SCATBA = (uint32_t)&data->dsct_sg[0];
+	pdma_inst->PDMA_SCATBA = (is_rx) ? ((uint32_t)&data->dsct_sg[0]) & 0xFFFF0000
+					 : ((uint32_t)&data->dsct_sg[2]) & 0xFFFF0000;
 
-	/* set 8 bits transfer width */
+	/* Set 8 bits transfer width */
 	SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_TXWIDTH, NCT_PDMA_DSCT_CTL_TX_WIDTH_8);
 
 	/* Set DMA single request type */
@@ -828,30 +909,39 @@ static int nct_i3c_pdma_configure(const struct device *dev, enum i3c_config_type
 	/* Set mode as basic means the last descriptor */
 	SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_OPMODE, NCT_PDMA_DSCT_CTL_OPMODE_BASIC);
 
-	/* For read DMA, fixed src address.
-	 * For write DMA, fixed dst address
+	/*
+	 * For read DMA, fixed src address.
+	 * For write DMA, fixed dst address.
 	 */
-	if (is_read) {
+	if (is_rx) {
 		/* Set transfer size, TXCNT + 1 */
 		SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_TXCNT, (buf_sz - 1));
 		SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_SAINC, NCT_PDMA_DSCT_CTL_SAINC_FIX);
 		SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_DAINC, 0x0);
 
-		src_addr = (uint32_t)&i3c_inst->MRDATAB;
+		/* Set source address */
+		src_addr = (type == I3C_CONFIG_CONTROLLER) ? (uint32_t)&i3c_inst->MRDATAB
+							   : (uint32_t)&i3c_inst->RDATAB;
+
+		/* Fixed destination address */
 		dst_addr = (uint32_t)&buf[0];
 	} else {
 		SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_DAINC, NCT_PDMA_DSCT_CTL_DAINC_FIX);
 		SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_SAINC, 0x0);
 
+		/* Fixed source address */
 		src_addr = (uint32_t)&buf[0];
 
 		/* Set transfer size, TXCNT + 1 */
 		SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_TXCNT, (buf_sz - 1));
 
+		/* Set destination address */
 		if (no_ending) {
-			dst_addr = (uint32_t)&i3c_inst->MWDATAB1;
+			dst_addr = (type == I3C_CONFIG_CONTROLLER) ? (uint32_t)&i3c_inst->MWDATAB1
+								   : (uint32_t)&i3c_inst->WDATAB1;
 		} else if (buf_sz > 1) {
-			/* In this case need use second descriptor table, re-configure
+			/*
+			 * In this case need use second descriptor table, re-configure
 			 * first descriptor SGM and (tx_length - 2), the last byte use
 			 * second decriptor table.
 			 */
@@ -859,38 +949,43 @@ static int nct_i3c_pdma_configure(const struct device *dev, enum i3c_config_type
 					NCT_PDMA_DSCT_CTL_OPMODE_SGM);
 			SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_TXCNT, (buf_sz - 2));
 
-			dst_addr = (uint32_t)&i3c_inst->MWDATAB1;
+			dst_addr = (type == I3C_CONFIG_CONTROLLER) ? (uint32_t)&i3c_inst->MWDATAB1
+								   : (uint32_t)&i3c_inst->WDATAB1;
 		} else {
-			dst_addr = (uint32_t)&i3c_inst->MWDATABE;
+			dst_addr = (type == I3C_CONFIG_CONTROLLER) ? (uint32_t)&i3c_inst->MWDATABE
+								   : (uint32_t)&i3c_inst->WDATABE;
 		}
 	}
 
-	memset(&data->dsct_sg, 0x0, sizeof(data->dsct_sg));
-
 	/* Set next descriptor */
-	dsct_inst->NEXT = (uint32_t)&data->dsct_sg[0];
-
+	if (is_rx) {
 	data->dsct_sg[0].CTL = ctrl;
 	data->dsct_sg[0].SA = src_addr;
 	data->dsct_sg[0].DA = dst_addr;
 	data->dsct_sg[0].NEXT = 0x0;
+	} else {
+		data->dsct_sg[2].CTL = ctrl;
+		data->dsct_sg[2].SA = src_addr;
+		data->dsct_sg[2].DA = dst_addr;
+		data->dsct_sg[2].NEXT = 0x0;
 
-	if (!is_read) {
 		/* If first descriptor use scatter-gather mode */
-		if (GET_FIELD(data->dsct_sg[0].CTL, NCT_PDMA_DSCT_CTL_OPMODE) ==
+		if (GET_FIELD(data->dsct_sg[2].CTL, NCT_PDMA_DSCT_CTL_OPMODE) ==
 				NCT_PDMA_DSCT_CTL_OPMODE_SGM) {
 			/* Configure next descriptor. */
-			data->dsct_sg[0].NEXT = (uint32_t)&data->dsct_sg[1];
+			data->dsct_sg[2].NEXT = (uint32_t)&data->dsct_sg[3];
 
 			/* Set basic mode for last descriptor */
 			SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_OPMODE,
 					NCT_PDMA_DSCT_CTL_OPMODE_BASIC);
 			SET_FIELD(ctrl, NCT_PDMA_DSCT_CTL_TXCNT, 0x0);
 
-			data->dsct_sg[1].CTL = ctrl;
-			data->dsct_sg[1].SA = (uint32_t)&buf[buf_sz - 1];
-			data->dsct_sg[1].DA = (uint32_t)&i3c_inst->MWDATABE;
-			data->dsct_sg[1].NEXT = 0x0;
+			data->dsct_sg[3].CTL = ctrl;
+			data->dsct_sg[3].SA = (uint32_t)&buf[buf_sz - 1];
+			data->dsct_sg[3].DA = (type == I3C_CONFIG_CONTROLLER)
+						      ? (uint32_t)&i3c_inst->MWDATABE
+						      : (uint32_t)&i3c_inst->WDATABE;
+			data->dsct_sg[3].NEXT = 0x0;
 		}
 	}
 
@@ -899,39 +994,220 @@ static int nct_i3c_pdma_configure(const struct device *dev, enum i3c_config_type
 	return 0;
 }
 
+static uint8_t nct_i3c_pdma_get_index(const struct device *dev, bool is_rx)
+{
+	struct pdma_dsct_reg *dsct_inst = NULL;
+	uint8_t dsct_idx;
+
+	dsct_idx = nct_i3c_pdma_dsct(dev, is_rx, &dsct_inst);
+	if (dsct_inst == NULL) {
+		LOG_ERR("dsct(%d) not exist", dsct_idx);
+		return -EINVAL;
+	}
+
+	return dsct_idx;
+}
+
+static int nct_i3c_controller_dma_on(const struct device *dev, bool is_rx)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	int ret = 0;
+
+	/* Enable PDMA */
+	ret = nct_i3c_pdma_start(dev, is_rx);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Enable DMA */
+	if (is_rx) {
+		/* Receive */
+		SET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMAFB,
+				   MDMA_DMAFB_EN_MANUAL);
+	} else {
+		/* Transmit */
+		SET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMATB,
+				   MDMA_DMATB_EN_MANUAL);
+	}
+
+	return 0;
+}
+
+static int nct_i3c_controller_dma_off(const struct device *dev, bool is_rx)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *const data = dev->data;
+	uint8_t dsct_idx = nct_i3c_pdma_get_index(dev, is_rx);
+	int ret = 0;
+
+	/* Only disable set DMA */
+	if (!(data->dma_triggered & BIT(dsct_idx))) {
+		return ret;
+	}
+
+	/* Disable DMA */
+	if (is_rx) {
+		if (GET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMAFB) !=
+		    MDMA_DMAFB_DISABLE) {
+			SET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMAFB,
+					   MDMA_DMAFB_DISABLE);
+		}
+	} else {
+		if (GET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMATB) !=
+		    MDMA_DMATB_DISABLE) {
+			SET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMATB,
+					   MDMA_DMATB_DISABLE);
+		}
+	}
+
+	/* Stop PDMA */
+	ret = nct_i3c_pdma_stop(dev, is_rx);
+
+	/* Flush FIFO */
+	nct_i3c_controller_fifo_flush(i3c_inst);
+
+	return ret;
+}
+
+static int nct_i3c_target_dma_on(const struct device *dev, bool is_rx)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	int ret = 0;
+
+	ret = nct_i3c_pdma_start(dev, is_rx);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (is_rx) {
+		SET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMAFB,
+				   DMA_DMAFB_EN_MANUAL);
+	} else {
+		SET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMATB,
+				   DMA_DMATB_EN_MANUAL);
+	}
+
+	return 0;
+}
+
+static int nct_i3c_target_dma_off(const struct device *dev, bool is_rx)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *const data = dev->data;
+	uint8_t dsct_idx = nct_i3c_pdma_get_index(dev, is_rx);
+	int ret = 0;
+
+	/* Only disable set DMA */
+	if (!(data->dma_triggered & BIT(dsct_idx))) {
+		return ret;
+	}
+
+	/* Disable DMA */
+	if (is_rx) {
+		/* Receive */
+		if (GET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMAFB) !=
+		    DMA_DMAFB_DISABLE) {
+			SET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMAFB,
+					   DMA_DMAFB_DISABLE);
+		}
+	} else {
+		/* Transmit */
+		if (GET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMATB) !=
+		    DMA_DMATB_DISABLE) {
+			SET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMATB,
+					   DMA_DMATB_DISABLE);
+		}
+	}
+
+	/* Stop PDMA */
+	ret = nct_i3c_pdma_stop(dev, is_rx);
+
+	/* Flush FIFO */
+	if (is_rx) {
+		nct_i3c_target_rx_fifo_flush(i3c_inst);
+	} else {
+		nct_i3c_target_tx_fifo_flush(i3c_inst);
+	}
+
+	return ret;
+}
+
+/*
+ * brief:  Perform I3C target DMA transaction.
+ *
+ * This function performs I3C target DMA transaction for read or write.
+ *
+ * param[in] dev       Pointer to controller device driver instance.
+ * param[in] is_rx     true=rx or false=tx operation.
+ * param[in] buf       Buffer containing data to be sent or received.
+ *                     The caller must ensure that the buffer is valid until the
+ *                     transaction is completed.
+ * param[in] buf_sz    Number of bytes in buf to send or receive.
+ * param[in] no_ending True if not to signal end of message.
+ *
+ * return  Number of bytes transferred, or negative if error.
+ *
+ */
+static int nct_i3c_target_do_request_dma(const struct device *dev, bool is_rx, uint8_t *buf,
+					  size_t buf_sz, bool no_ending)
+{
+	int ret;
+
+	/* Stop previous PDMA */
+	nct_i3c_target_dma_off(dev, is_rx);
+
+	/* Configure PDMA */
+	ret = nct_i3c_pdma_configure(dev, I3C_CONFIG_TARGET, is_rx, buf, buf_sz, no_ending);
+	if (ret != 0) {
+		goto err_out;
+	}
+
+	/* Enable PDMA */
+	if (nct_i3c_target_dma_on(dev, is_rx) < 0) {
+		ret = -EIO;
+		goto err_out;
+	}
+
+	/* Check remian data count */
+	ret = nct_i3c_pdma_remain_count(dev, is_rx);
+	if (ret >= 0) {
+		return (buf_sz - ret);
+	}
+
+err_out:
+	nct_i3c_target_dma_off(dev, is_rx);
+
+	return ret;
+}
+
 static int nct_i3c_ctlr_xfer_read_fifo_dma(const struct device *dev, uint8_t addr,
-				enum nct_i3c_mctrl_type op_type, uint8_t *buf, size_t buf_sz,
-				bool is_read, bool emit_start, bool emit_stop, bool no_ending)
+					    enum nct_i3c_mctrl_type op_type, uint8_t *buf,
+					    size_t buf_sz, bool is_rx, bool emit_start,
+					    bool emit_stop, bool no_ending)
 {
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
 	int ret;
 
-	ret = nct_i3c_pdma_configure(dev, I3C_CONFIG_CONTROLLER, true, buf, buf_sz,
-					no_ending);
+	/* Stop PDMA */
+	nct_i3c_target_dma_off(dev, true);
+
+	ret = nct_i3c_pdma_configure(dev, I3C_CONFIG_CONTROLLER, true, buf, buf_sz, no_ending);
 	if (ret) {
 		return ret;
 	}
 
-	/* Enable PDMA before emit start */
-	ret = nct_i3c_pdma_start(dev, true);
+	/* Enable DMA until DMA is disabled by setting DMAFB to 00 */
+	ret = nct_i3c_controller_dma_on(dev, true);
 	if (ret) {
 		goto out_read_fifo_dma;
 	}
 
-	/* Enable DMA until DMA is disabled by setting DMAFB to 00 */
-	SET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMAFB, MDMA_DMAFB_EN_MANUAL);
-
 	/* Emit START if needed */
 	if (emit_start) {
-		ret = nct_i3c_request_emit_start(i3c_inst, addr, op_type, is_read, buf_sz);
+		ret = nct_i3c_request_emit_start(i3c_inst, addr, op_type, is_rx, buf_sz);
 		if (ret != 0) {
 			goto out_read_fifo_dma;
 		}
-	}
-
-	/* No data to be transferred */
-	if ((buf == NULL) || (buf_sz == 0)) {
-		goto out_read_fifo_dma;
 	}
 
 	if (no_ending) {
@@ -945,20 +1221,13 @@ static int nct_i3c_ctlr_xfer_read_fifo_dma(const struct device *dev, uint8_t add
 
 		ret = nct_i3c_ctrl_wait_completion(dev);
 		if (ret) {
-			i3c_inst->MINTCLR = BIT(NCT_I3C_MINTCLR_COMPLETE);
-			LOG_ERR("i3c wait completion timeout");
+			i3c_inst->MINTCLR = NCT_I3C_MINTCLR_COMPLETE;
+			LOG_ERR("i3c wait completion timeout 1");
 		}
 	}
 
 out_read_fifo_dma:
-	/* Disable DMA */
-	if (GET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMAFB) !=
-			MDMA_DMAFB_DISABLE) {
-		SET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMAFB,
-					MDMA_DMAFB_DISABLE);
-	}
-
-	if (nct_i3c_pdma_stop(dev, true)) {
+	if (nct_i3c_controller_dma_off(dev, true) < 0) {
 		ret = -EIO;
 	}
 
@@ -978,27 +1247,28 @@ out_read_fifo_dma:
 }
 
 static int nct_i3c_ctlr_xfer_write_fifo_dma(const struct device *dev, uint8_t addr,
-				enum nct_i3c_mctrl_type op_type, uint8_t *buf, size_t buf_sz,
-				bool is_read, bool emit_start, bool emit_stop, bool no_ending)
+					     enum nct_i3c_mctrl_type op_type, uint8_t *buf,
+					     size_t buf_sz, bool is_rx, bool emit_start,
+					     bool emit_stop, bool no_ending)
 {
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
 	uint32_t key;
 	int ret;
 
-	ret = nct_i3c_pdma_configure(dev, I3C_CONFIG_CONTROLLER, false, buf, buf_sz,
-					no_ending);
+	ret = nct_i3c_pdma_configure(dev, I3C_CONFIG_CONTROLLER, false, buf, buf_sz, no_ending);
 	if (ret) {
 		return ret;
 	}
 
-	/* For write operation, we enable dma after emit start. Disable all interrupts
+	/*
+	 * For write operation, we enable dma after emit start. Disable all interrupts
 	 * to avoid i3c stall timeout.
 	 */
 	key = irq_lock();
 
 	/* Emit START if needed */
 	if (emit_start) {
-		ret = nct_i3c_request_emit_start(i3c_inst, addr, op_type, is_read, buf_sz);
+		ret = nct_i3c_request_emit_start(i3c_inst, addr, op_type, is_rx, buf_sz);
 		if (ret != 0) {
 			irq_unlock(key);
 			return ret;
@@ -1006,22 +1276,14 @@ static int nct_i3c_ctlr_xfer_write_fifo_dma(const struct device *dev, uint8_t ad
 	}
 
 	/* Enable PDMA after emit start */
-	ret = nct_i3c_pdma_start(dev, false);
+	ret = nct_i3c_controller_dma_on(dev, false);
 	if (ret) {
 		irq_unlock(key);
 		goto out_write_fifo_dma;
 	}
 
-	/* Enable DMA until DMA is disabled by setting DMATB to 00 */
-	SET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMATB, MDMA_DMATB_EN_MANUAL);
-
 	/* Enable interrupts */
 	irq_unlock(key);
-
-	/* No data to be transferred */
-	if ((buf == NULL) || (buf_sz == 0)) {
-		goto out_write_fifo_dma;
-	}
 
 	if (no_ending) {
 		ret = nct_i3c_pdma_wait_completion(dev, false);
@@ -1031,23 +1293,15 @@ static int nct_i3c_ctlr_xfer_write_fifo_dma(const struct device *dev, uint8_t ad
 	} else {
 		/* Enable COMPLETE interrupt */
 		i3c_inst->MINTSET |= BIT(NCT_I3C_MINTSET_COMPLETE);
-
 		ret = nct_i3c_ctrl_wait_completion(dev);
 		if (ret) {
 			i3c_inst->MINTCLR = BIT(NCT_I3C_MINTCLR_COMPLETE);
-			LOG_ERR("i3c wait completion timeout");
+			LOG_ERR("i3c wait completion timeout 2");
 		}
 	}
 
 out_write_fifo_dma:
-	/* Disable DMA */
-	if (GET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMATB) !=
-			MDMA_DMATB_DISABLE) {
-		SET_FIELD(i3c_inst->MDMACTRL, NCT_I3C_MDMACTRL_DMATB,
-					MDMA_DMATB_DISABLE);
-	}
-
-	if (nct_i3c_pdma_stop(dev, false)) {
+	if (nct_i3c_controller_dma_off(dev, false) < 0) {
 		ret = -EIO;
 	}
 
@@ -1074,7 +1328,7 @@ out_write_fifo_dma:
  * param[in] op_type     Request type.
  * param[in] buf         Buffer for data to be sent or received.
  * param[in] buf_sz      Buffer size in bytes.
- * param[in] is_read     True if this is a read transaction, false if write.
+ * param[in] is_rx    true=rx or false=tx operation.
  * param[in] emit_start  True if START is needed before read/write.
  * param[in] emit_stop   True if STOP is needed after read/write.
  * param[in] no_ending   True if not to signal end of message.
@@ -1083,7 +1337,7 @@ out_write_fifo_dma:
  */
 static int nct_i3c_do_one_xfer_dma(const struct device *dev, uint8_t addr,
 				    enum nct_i3c_mctrl_type op_type, uint8_t *buf, size_t buf_sz,
-				    bool is_read, bool emit_start, bool emit_stop, bool no_ending)
+				    bool is_rx, bool emit_start, bool emit_stop, bool no_ending)
 {
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
 	int ret = 0;
@@ -1091,33 +1345,582 @@ static int nct_i3c_do_one_xfer_dma(const struct device *dev, uint8_t addr,
 	nct_i3c_status_clear_all(i3c_inst);
 	nct_i3c_errwarn_clear_all(i3c_inst);
 
-	if (is_read) {
-		ret = nct_i3c_ctlr_xfer_read_fifo_dma(dev, addr, op_type, buf, buf_sz,
-				is_read, emit_start, emit_stop, no_ending);
+	if (is_rx) {
+		ret = nct_i3c_ctlr_xfer_read_fifo_dma(dev, addr, op_type, buf, buf_sz, is_rx,
+						       emit_start, emit_stop, no_ending);
 	} else {
-		ret = nct_i3c_ctlr_xfer_write_fifo_dma(dev, addr, op_type, buf, buf_sz,
-				is_read, emit_start, emit_stop, no_ending);
+		ret = nct_i3c_ctlr_xfer_write_fifo_dma(dev, addr, op_type, buf, buf_sz, is_rx,
+							emit_start, emit_stop, no_ending);
 	}
 
 	if (ret < 0) {
-		LOG_ERR("%s fifo fail", is_read ? "read" : "write");
+		LOG_ERR("%s fifo fail", is_rx ? "read" : "write");
 		return ret;
 	}
 
 	/* Check I3C bus error */
 	if (nct_i3c_has_error(i3c_inst)) {
-		LOG_ERR("I3C bus error");
+		LOG_ERR("I3C bus error, 0x%08x", i3c_inst->MERRWARN);
 		return -EIO;
 	}
 
 	if (no_ending) {
 		/* Flush fifo data */
-		nct_i3c_fifo_flush(i3c_inst);
+		nct_i3c_controller_fifo_flush(i3c_inst);
 	}
 
 	return ret;
 }
+
+/* brief:  Handle the end of transfer (read request or write request).
+ *         The ending signal might be either STOP or Sr.
+ * return: -EINVAL: operation not read or write request.
+ *         -ETIMEDOUT: in write request, wait rx fifo empty as pdma done.
+ *          0: success
+ */
+static int nct_i3c_target_xfer_end_handle_dma(const struct device *dev,
+					       enum nct_i3c_oper_state oper_state)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *const data = dev->data;
+
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE	
+	const struct i3c_target_callbacks *target_cb =
+		(data->target_config != NULL) ? data->target_config->callbacks : NULL;
+#endif
+	uint8_t len = 0;
+	uint8_t rx_fifo_count;
+	bool is_rx;
+	int ret = 0;
+	int i;
+
+	if (oper_state == I3C_OP_STATE_RD) {
+		is_rx = false;
+
+		/* After STOP, the data in tx fifo is invalid. */
+		data->tx_valid = false;
+
+		goto out_pdma_end;
+	} else if (oper_state == I3C_OP_STATE_WR) {
+		is_rx = true;
+
+		/* Wait until rx fifo is stable */
+#define RX_FIFO_EMPTY_TIMEOUT 100
+		len = GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_RXCOUNT);
+		for (i = 0; i < RX_FIFO_EMPTY_TIMEOUT; i++) {
+			/* For 12.5MHz, [data] + [T] = 0.75us */
+			k_busy_wait(10);
+			rx_fifo_count =
+				GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_RXCOUNT);
+
+			if (len == rx_fifo_count) {
+				break;
+			} else {
+				len = rx_fifo_count;
+			}
+		}
+
+		if (len) {
+			ret = nct_i3c_target_do_request_dma(dev, is_rx, data->dma_rx_buf, len,
+							     false);
+			if (ret < 0) {
+				LOG_ERR("DMA write request failed");
+				goto out_pdma_end;
+			}
+
+			ret = nct_i3c_pdma_wait_completion(dev, is_rx);
+			if (ret) {
+				LOG_ERR("i3c wait dma completion timeout");
+			}
+
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+			if (target_cb && target_cb->buf_write_received_cb) {
+				target_cb->buf_write_received_cb(data->target_config,
+								 data->dma_rx_buf, len);
+			}
+
+			// For V2.6 mctp
+			if (data->slave_data.callbacks != NULL) {
+				if (data->slave_data.callbacks->write_requested != NULL) {
+					struct i3c_config_target *config_tgt = &data->config_target;
+
+					data->rx_payload = data->slave_data.callbacks->write_requested(
+						data->slave_data.dev);
+
+					data->rx_payload->size = config_tgt->max_read_len;
+				}
+
+				memcpy(data->rx_payload->buf, data->dma_rx_buf, len);
+				data->rx_payload->size = len;
+
+				if (data->slave_data.callbacks->write_done != NULL) {
+					data->slave_data.callbacks->write_done(data->slave_data.dev);
+				}
+			}
+#endif
+		} else {
+			LOG_ERR("rx fifo empty");
+		}
+	} else {
+		LOG_ERR("oper_state error :%d", oper_state);
+		return -EINVAL;
+	}
+
+out_pdma_end:
+	nct_i3c_target_dma_off(dev, is_rx);
+
+	return ret;
+}
+
+static int nct_i3c_pdma_stop_v2(const struct device *dev, bool is_rx)
+{
+	struct nct_i3c_data *const data = dev->data;
+	struct i3c_config_target *config_tgt = &data->config_target;
+	struct pdma_dsct_reg *dsct_inst = NULL;
+	struct pdma_reg *pdma_inst;
+	uint8_t dsct_idx;
+	uint32_t key;
+
+	dsct_idx = nct_i3c_pdma_dsct(dev, is_rx, &dsct_inst);
+	if (dsct_inst == NULL) {
+		LOG_ERR("dsct(%d) not exist", is_rx);
+		return -EINVAL;
+	}
+
+	/* Get pdma base address */
+	pdma_inst = (struct pdma_reg *)NCT_PDMA_BASE((uint32_t)dsct_inst);
+	if (pdma_inst == NULL) {
+		LOG_ERR("pdma base address not exist.");
+		return -EINVAL;
+	}
+
+	key = irq_lock();
+
+	/* Clear transfer done flag */
+	if (pdma_inst->PDMA_TDSTS & BIT(dsct_idx)) {
+		pdma_inst->PDMA_TDSTS |= BIT(dsct_idx);
+
+		// update slave rcv data length before reset TDSTS
+		if (config_tgt->enable && is_rx) {
+			data->slave_rx_payload[data->rx_payload_out].size = config_tgt->max_read_len;
+		}
+	}
+	else {
+		if (config_tgt->enable && is_rx) {
+			data->slave_rx_payload[data->rx_payload_out].size = config_tgt->max_read_len - 
+				(GET_FIELD(dsct_inst->CTL, NCT_PDMA_DSCT_CTL_TXCNT) + 1);
+		}
+	}
+
+	pdma_inst->PDMA_CHCTL &= ~BIT(dsct_idx);
+
+	/* Clear DMA triggered flag */
+	data->dma_triggered &= ~BIT(dsct_idx);
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+
+static int nct_i3c_target_dma_off_v2(const struct device *dev, bool is_rx)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *const data = dev->data;
+	uint8_t dsct_idx = nct_i3c_pdma_get_index(dev, is_rx);
+	int ret = 0;
+
+	/* Only disable set DMA */
+	if (!(data->dma_triggered & BIT(dsct_idx))) {
+		return ret;
+	}
+
+	/* Disable DMA */
+	if (is_rx) {
+		/* Receive */
+		if (GET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMAFB) !=
+		    DMA_DMAFB_DISABLE) {
+			SET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMAFB,
+					   DMA_DMAFB_DISABLE);
+		}
+	} else {
+		/* Transmit */
+		if (GET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMATB) !=
+		    DMA_DMATB_DISABLE) {
+			SET_FIELD(i3c_inst->DMACTRL, NCT_I3C_DMACTRL_DMATB,
+					   DMA_DMATB_DISABLE);
+		}
+	}
+
+	/* Stop PDMA */
+	ret = nct_i3c_pdma_stop_v2(dev, is_rx);
+
+	/* Flush FIFO */
+	if (is_rx) {
+		nct_i3c_target_rx_fifo_flush(i3c_inst);
+	} else {
+		nct_i3c_target_tx_fifo_flush(i3c_inst);
+	}
+
+	return ret;
+}
+
+static int nct_i3c_target_do_request_dma_v2(const struct device *dev, bool is_rx, uint8_t *buf,
+					  size_t buf_sz, bool no_ending)
+{
+	int ret;
+
+	/* Stop the previous PDMA */
+	nct_i3c_target_dma_off_v2(dev, is_rx);
+
+	/* Configure PDMA */
+	ret = nct_i3c_pdma_configure(dev, I3C_CONFIG_TARGET, is_rx, buf, buf_sz, no_ending);
+	if (ret != 0) {
+		goto err_out;
+	}
+
+	/* Enable PDMA */
+	if (nct_i3c_target_dma_on(dev, is_rx) < 0) {
+		ret = -EIO;
+		goto err_out;
+	}
+
+	/* Check remian data count */
+	ret = nct_i3c_pdma_remain_count(dev, is_rx);
+	if (ret >= 0) {
+		return (buf_sz - ret);
+	}
+
+err_out:
+	nct_i3c_target_dma_off(dev, is_rx);
+
+	return ret;
+}
+
+static int nct_i3c_target_xfer_end_handle_dma_v2(const struct device *dev,
+					       enum nct_i3c_oper_state oper_state)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *const data = dev->data;
+	struct i3c_config_target *config_tgt = &data->config_target;
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+	const struct i3c_target_callbacks *target_cb =
+		(data->target_config != NULL) ? data->target_config->callbacks : NULL;
+#endif
+	uint16_t len = 0;
+	uint16_t rx_fifo_count;
+	bool is_rx;
+	int ret = 0;
+	int i;
+
+	if (oper_state == I3C_OP_STATE_RD) {
+		is_rx = false;
+
+		len = GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_TXCOUNT);
+		if (len == 0) {
+        	if (tx_fifo_empty_cb) {
+        		tx_fifo_empty_cb();
+        	}
+		}
+
+		/* After STOP, the data in tx fifo is invalid. */
+		data->tx_valid = false;
+
+		goto out_pdma_end;
+	} else if (oper_state == I3C_OP_STATE_WR) {
+		is_rx = true;
+
+		/* Wait until no data insert into rx fifo */
+#define RX_FIFO_EMPTY_TIMEOUT 100
+		len = GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_RXCOUNT);
+		for (i = 0; i < RX_FIFO_EMPTY_TIMEOUT; i++) {
+			/* For 12.5MHz, [data] + [T] = 0.75us */
+			k_busy_wait(10);
+			rx_fifo_count =
+				GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_RXCOUNT);
+
+			if (len == rx_fifo_count) {
+				break;
+			} else {
+				len = rx_fifo_count;
+			}
+		}
+
+		update_i3c_slave_rx_payload(dev);		
+
+		struct i3c_slave_payload *new_payload = alloc_i3c_slave_rx_payload(dev);
+		new_payload->size = config_tgt->max_read_len;
+
+		is_rx = true;
+		bool no_ending = false;
+
+		ret = nct_i3c_target_do_request_dma_v2(dev, is_rx, new_payload->buf, config_tgt->max_read_len, no_ending);
+		if (ret < 0) {
+			LOG_ERR("do xfer fail");
+		}
+
+		// process the received data
+		len = data->slave_rx_payload[data->rx_payload_out].size;
+
+	#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+		if (target_cb && target_cb->buf_write_received_cb) {
+			target_cb->buf_write_received_cb(data->target_config, 
+				data->slave_rx_payload[data->rx_payload_out].buf, len);
+		}
+	#endif
+		// For V2.6 mctp
+		if (data->slave_data.callbacks != NULL) {
+			if (data->slave_data.callbacks->write_requested != NULL) {
+				data->rx_payload = data->slave_data.callbacks->write_requested(
+					data->slave_data.dev);
+
+				data->rx_payload->size = config_tgt->max_read_len;
+			}
+
+			memcpy(data->rx_payload->buf, data->slave_rx_payload[data->rx_payload_out].buf, len);
+			data->rx_payload->size = len;
+
+			if (data->slave_data.callbacks->write_done != NULL) {
+				data->slave_data.callbacks->write_done(data->slave_data.dev);
+			}
+		}
+
+		data->rx_payload_out = (data->rx_payload_out + 1) % ARRAY_SIZE(data->pdma_rx_buf);
+		return 0;
+	} else if (oper_state == I3C_OP_STATE_CCC) {
+		is_rx = true;
+
+		/* Wait until no data insert into rx fifo */
+#define RX_FIFO_EMPTY_TIMEOUT 100
+		len = GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_RXCOUNT);
+		for (i = 0; i < RX_FIFO_EMPTY_TIMEOUT; i++) {
+			/* For 12.5MHz, [data] + [T] = 0.75us */
+			k_busy_wait(10);
+			rx_fifo_count =
+				GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_RXCOUNT);
+
+			if (len == rx_fifo_count) {
+				break;
+			} else {
+				len = rx_fifo_count;
+			}
+		}	
+
+		update_i3c_slave_rx_payload(dev);
+
+		struct i3c_slave_payload *new_payload = alloc_i3c_slave_rx_payload(dev);
+		new_payload->size = config_tgt->max_read_len;
+
+		is_rx = true;
+		bool no_ending = false;
+
+		ret = nct_i3c_target_do_request_dma_v2(dev, is_rx, new_payload->buf, config_tgt->max_read_len, no_ending);
+		if (ret < 0) {
+			LOG_ERR("do xfer fail");
+		}
+
+		// process the received data
+		len = data->slave_rx_payload[data->rx_payload_out].size;
+
+		// call CCC handler
+		uint8_t buf[10];
+		uint8_t rcv_cnt;
+
+		rcv_cnt = data->slave_rx_payload[data->rx_payload_out].size;
+		memcpy(buf, data->slave_rx_payload[data->rx_payload_out].buf, rcv_cnt);
+
+		if (buf[0] == I3C_CCC_RSTACT(true)) {
+			LOG_DBG("CCC RSTACT received");
+		}
+
+		data->rx_payload_out = (data->rx_payload_out + 1) % ARRAY_SIZE(data->pdma_rx_buf);
+		return 0;
+	} else {
+		LOG_ERR("oper_state error :%d", oper_state);
+		return -EINVAL;
+	}
+
+out_pdma_end:
+	nct_i3c_target_dma_off(dev, is_rx);
+
+	return ret;
+}
+#else
+static bool nct_i3c_target_has_error(struct i3c_reg *i3c_inst)
+{
+	if (i3c_inst->STATUS & NCT_I3C_STATUS_ERRWARN) {
+		LOG_WRN("ERROR: STATUS 0x%08x ERRWARN 0x%08x", i3c_inst->STATUS, i3c_inst->ERRWARN);
+
+		return true;
+	}
+
+	return false;
+}
+
+/* brief:  Handle the end of transfer (read request or write request).
+ *         The ending signal might be either STOP or Sr.
+ * return: -EINVAL: operation not read or write request.
+ *         -ETIMEDOUT: in write request, wait rx fifo empty as pdma done.
+ *          0: success
+ */
+static int nct_i3c_target_xfer_end_handle(const struct device *dev,
+					   enum nct_i3c_oper_state oper_state)
+
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *const data = dev->data;
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+	const struct i3c_target_callbacks *target_cb =
+		(data->target_config != NULL) ? data->target_config->callbacks : NULL;
+#endif
+	int ret = 0;
+
+	if (oper_state == I3C_OP_STATE_RD) {
+		/* Set buffer invalid */
+		data->tx_len = 0;
+
+		nct_i3c_target_tx_fifo_flush(i3c_inst);
+	} else if (oper_state == I3C_OP_STATE_WR) {
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+		if (target_cb && target_cb->buf_write_received_cb) {
+			target_cb->buf_write_received_cb(data->target_config, data->rx_buf,
+							 data->rx_len);
+		}
+
+		nct_i3c_target_rx_fifo_flush(i3c_inst);
+#endif
+	}
+
+	return ret;
+}
+
+/*
+ * brief:  Perform one write transaction.
+ *
+ * This writes all data in buf to TX FIFO or time out
+ * waiting for FIFO spaces.
+ *
+ * param[in] i3c_inst   Pointer to controller registers.
+ * param[in] buf        Buffer containing data to be sent.
+ * param[in] buf_sz     Number of bytes in buf to send.
+ * param[in] no_ending  True if not to signal end of message.
+ *
+ * return  Number of bytes written, or negative if error.
+ *
+ */
+static int nct_i3c_xfer_target_write_fifo(struct i3c_reg *i3c_inst, uint8_t *buf, uint8_t buf_sz,
+					   bool no_ending)
+{
+	int remaining;
+	int offset;
+	int tx_remain;
+	int i;
+
+	/* Set buf_sz - 1 bytes */
+	for (offset = 0, remaining = buf_sz - 1; remaining > 0;
+	     offset += tx_remain, remaining -= tx_remain) {
+		if (WAIT_FOR(GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_TXCOUNT) <
+				     I3C_FIFO_SIZE,
+			     I3C_CHK_TIMEOUT_US, NULL) == false) {
+			return -ETIMEDOUT;
+		}
+
+		tx_remain = I3C_FIFO_SIZE -
+			    GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_TXCOUNT);
+		tx_remain = (tx_remain > remaining) ? remaining : tx_remain;
+
+		for (i = 0; i < tx_remain; i++) {
+			i3c_inst->WDATAB = (uint32_t)buf[offset + i];
+		}
+	}
+
+	/* Set last byte */
+	if (no_ending) {
+		i3c_inst->WDATAB = (uint32_t)buf[offset++];
+	} else {
+		i3c_inst->WDATABE = (uint32_t)buf[offset++];
+	}
+
+	return offset;
+}
+
+/*
+ * brief:  Perform read transaction.
+ *
+ * This reads from RX FIFO until COMPLETE bit is set in MSTATUS
+ * or time out.
+ *
+ * param[in] i3c_inst  Pointer to controller registers.
+ * param[in] buf       Buffer to store data.
+ *
+ * return  Number of bytes read, or negative if error.
+ *
+ */
+static int nct_i3c_xfer_target_read_fifo(struct i3c_reg *i3c_inst, uint8_t *buf)
+{
+	bool is_done = false;
+	int offset = 0;
+
+	while (is_done == false) {
+		/* Check tarnsaction is done */
+		if ((i3c_inst->STATUS & NCT_I3C_STATUS_STOP) ||
+		    (i3c_inst->STATUS & NCT_I3C_STATUS_START)) {
+			is_done = true;
+		}
+
+		/* Check message is canceled */
+		if (i3c_inst->STATUS & NCT_I3C_STATUS_CHANDLED) {
+			is_done = true;
+		}
+
+		/* Check I3C bus error */
+		if (nct_i3c_target_has_error(i3c_inst)) {
+			/* Check timeout */
+			if (i3c_inst->ERRWARN & NCT_I3C_ERRWARN_TERM) {
+				LOG_WRN("ERR: terminated");
+			}
+
+			i3c_inst->ERRWARN = i3c_inst->ERRWARN;
+
+			return -EIO;
+		}
+
+		/* Check rx not empty */
+		if (i3c_inst->STATUS & NCT_I3C_STATUS_RXPEND) {
+			/*
+			 * Receive all the data in this round.
+			 * Read in a tight loop to reduce chance of losing
+			 * FIFO data when the i3c speed is high.
+			 */
+			while (GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_RXCOUNT)) {
+				buf[offset++] = (uint8_t)i3c_inst->RDATAB;
+			}
+		}
+	}
+
+	return offset;
+}
 #endif /* End of CONFIG_I3C_NCT_DMA */
+
+// setup rx pdma for target to receive request from controller
+static void nct_i3c_target_rx_read(const struct device *dev)
+{
+	struct nct_i3c_data *data = dev->data;
+	struct i3c_config_target *config_tgt = &data->config_target;
+
+#ifdef CONFIG_I3C_NCT_DMA
+	bool is_rx = true;
+	bool no_ending = false;
+
+	struct i3c_slave_payload *new_payload = alloc_i3c_slave_rx_payload(dev);
+	new_payload->size = config_tgt->max_read_len;
+
+	int ret = nct_i3c_target_do_request_dma_v2(dev, is_rx, new_payload->buf, config_tgt->max_read_len, no_ending);
+	if (ret < 0) {
+		LOG_ERR("do xfer fail");
+	}
+#endif	
+}
 
 /*
  * brief:  Perform one transfer transaction.
@@ -1127,7 +1930,7 @@ static int nct_i3c_do_one_xfer_dma(const struct device *dev, uint8_t addr,
  * param[in] op_type     Request type.
  * param[in] buf         Buffer for data to be sent or received.
  * param[in] buf_sz      Buffer size in bytes.
- * param[in] is_read     True if this is a read transaction, false if write.
+ * param[in] is_rx       true=rx or false=tx operation.
  * param[in] emit_start  True if START is needed before read/write.
  * param[in] emit_stop   True if STOP is needed after read/write.
  * param[in] no_ending   True if not to signal end of write message.
@@ -1136,7 +1939,7 @@ static int nct_i3c_do_one_xfer_dma(const struct device *dev, uint8_t addr,
  */
 static int nct_i3c_do_one_xfer(const struct device *dev, uint8_t addr,
 				enum nct_i3c_mctrl_type op_type, uint8_t *buf, size_t buf_sz,
-				bool is_read, bool emit_start, bool emit_stop, bool no_ending)
+				bool is_rx, bool emit_start, bool emit_stop, bool no_ending)
 {
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
 	int ret = 0;
@@ -1146,7 +1949,7 @@ static int nct_i3c_do_one_xfer(const struct device *dev, uint8_t addr,
 
 	/* Emit START if needed */
 	if (emit_start) {
-		ret = nct_i3c_request_emit_start(i3c_inst, addr, op_type, is_read, buf_sz);
+		ret = nct_i3c_request_emit_start(i3c_inst, addr, op_type, is_rx, buf_sz);
 		if (ret != 0) {
 			goto out_do_one_xfer;
 		}
@@ -1158,24 +1961,24 @@ static int nct_i3c_do_one_xfer(const struct device *dev, uint8_t addr,
 	}
 
 	/* Select read or write operation */
-	if (is_read) {
+	if (is_rx) {
 		ret = nct_i3c_xfer_read_fifo(i3c_inst, buf, buf_sz);
 	} else {
 		ret = nct_i3c_xfer_write_fifo(i3c_inst, buf, buf_sz, no_ending);
 	}
 
 	if (ret < 0) {
-		LOG_ERR("%s fifo fail", is_read ? "read" : "write");
+		LOG_ERR("%s fifo fail", is_rx ? "read" : "write");
 		goto out_do_one_xfer;
 	}
 
 	/* Check message complete if is a read transaction or
 	 * ending byte of a write transaction.
 	 */
-	if (is_read || !no_ending) {
+	if (is_rx || !no_ending) {
 		/* Wait message transfer complete */
-		if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE),
-			     NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+		if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE), I3C_CHK_TIMEOUT_US,
+			     NULL) == false) {
 			LOG_ERR("timed out addr 0x%02x, buf_sz %u", addr, buf_sz);
 
 			ret = -ETIMEDOUT;
@@ -1235,7 +2038,7 @@ static int nct_i3c_transfer(const struct device *dev, struct i3c_device_desc *ta
 
 	/* Check bus in idle state */
 	if (WAIT_FOR((nct_i3c_state_get(i3c_inst) == MSTATUS_STATE_IDLE),
-				NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+		     I3C_CHK_TIMEOUT_US, NULL) == false) {
 		LOG_ERR("xfer state error: %d", nct_i3c_state_get(i3c_inst));
 		nct_i3c_mutex_unlock(dev);
 		return -ETIMEDOUT;
@@ -1249,8 +2052,7 @@ static int nct_i3c_transfer(const struct device *dev, struct i3c_device_desc *ta
 
 	/* Iterate over all the messages */
 	for (int i = 0; i < num_msgs; i++) {
-
-		bool is_read = (msgs[i].flags & I3C_MSG_RW_MASK) == I3C_MSG_READ;
+		bool is_rx = (msgs[i].flags & I3C_MSG_RW_MASK) == I3C_MSG_READ;
 		bool no_ending = false;
 
 		/*
@@ -1270,7 +2072,7 @@ static int nct_i3c_transfer(const struct device *dev, struct i3c_device_desc *ta
 		 * message to be the last byte of a series of write mssages.
 		 * If not, tell the write function not to treat it that way.
 		 */
-		if (!is_read && !emit_stop && ((i + 1) != num_msgs)) {
+		if (!is_rx && !emit_stop && ((i + 1) != num_msgs)) {
 			bool next_is_write = (msgs[i + 1].flags & I3C_MSG_RW_MASK) == I3C_MSG_WRITE;
 			bool next_is_restart =
 				((msgs[i + 1].flags & I3C_MSG_RESTART) == I3C_MSG_RESTART);
@@ -1301,13 +2103,13 @@ static int nct_i3c_transfer(const struct device *dev, struct i3c_device_desc *ta
 
 #ifdef CONFIG_I3C_NCT_DMA
 		/* Do transfer with target device */
-		xfered_len = nct_i3c_do_one_xfer_dma(dev, target->dynamic_addr,
-						      NCT_I3C_MCTRL_TYPE_I3C, msgs[i].buf, msgs[i].len,
-						      is_read, emit_start, emit_stop, no_ending);
+		xfered_len = nct_i3c_do_one_xfer_dma(dev, target->dynamic_addr, NCT_I3C_MCTRL_TYPE_I3C,
+						      msgs[i].buf, msgs[i].len, is_rx, emit_start,
+						      emit_stop, no_ending);
 #else
-		xfered_len = nct_i3c_do_one_xfer(dev, target->dynamic_addr,
-						  NCT_I3C_MCTRL_TYPE_I3C, msgs[i].buf, msgs[i].len,
-						  is_read, emit_start, emit_stop, no_ending);
+		xfered_len = nct_i3c_do_one_xfer(dev, target->dynamic_addr, NCT_I3C_MCTRL_TYPE_I3C,
+						  msgs[i].buf, msgs[i].len, is_rx, emit_start,
+						  emit_stop, no_ending);
 #endif
 		if (xfered_len < 0) {
 			LOG_ERR("do xfer fail");
@@ -1340,7 +2142,6 @@ static int nct_i3c_transfer(const struct device *dev, struct i3c_device_desc *ta
 	nct_i3c_interrupt_enable(i3c_inst, intmask);
 
 	nct_i3c_mutex_unlock(dev);
-
 	return ret;
 }
 
@@ -1374,7 +2175,7 @@ static int nct_i3c_do_daa(const struct device *dev)
 
 	/* Check bus in idle state */
 	if (WAIT_FOR((nct_i3c_state_get(i3c_inst) == MSTATUS_STATE_IDLE),
-				NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+		     I3C_CHK_TIMEOUT_US, NULL) == false) {
 		LOG_ERR("DAA state error: %d", nct_i3c_state_get(i3c_inst));
 		nct_i3c_mutex_unlock(dev);
 		return -ETIMEDOUT;
@@ -1420,7 +2221,7 @@ static int nct_i3c_do_daa(const struct device *dev)
 
 		/* Start assign dynamic address */
 		if ((nct_i3c_state_get(i3c_inst) == MSTATUS_STATE_DAA) &&
-		    IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_BETWEEN)) {
+		    (IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_BETWEEN))) {
 			struct i3c_device_desc *target;
 			uint16_t vendor_id;
 			uint32_t part_no;
@@ -1470,6 +2271,9 @@ static int nct_i3c_do_daa(const struct device *dev)
 			 */
 			if ((target != NULL) && (target->static_addr != 0U) &&
 			    (dyn_addr != target->static_addr)) {
+
+				LOG_DBG("Free static address 0x%02x", target->static_addr);
+
 				i3c_addr_slots_mark_free(&data->common.attached_dev.addr_slots,
 							 dyn_addr);
 			}
@@ -1486,7 +2290,7 @@ static int nct_i3c_do_daa(const struct device *dev)
 				part_no, dyn_addr);
 
 			/* Target did not accept the assigned DA, exit DAA */
-			if (IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_NACKED)) {
+			if (i3c_inst->MSTATUS & NCT_I3C_MSTATUS_NACKED) {
 				ret = -EFAULT;
 				LOG_DBG("TGT NACK assigned DA %#x", dyn_addr);
 
@@ -1504,7 +2308,7 @@ static int nct_i3c_do_daa(const struct device *dev)
 		}
 
 		/* Check all targets have been assigned DA and DAA complete */
-	} while ((!IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE)) &&
+	} while ((!(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE))) &&
 		 nct_i3c_state_get(i3c_inst) != MSTATUS_STATE_IDLE);
 
 out_do_daa:
@@ -1520,7 +2324,7 @@ out_do_daa:
 	/* Re-Enable I3C IRQ sources. */
 	nct_i3c_interrupt_enable(i3c_inst, intmask);
 
-	nct_i3c_fifo_flush(i3c_inst);
+	nct_i3c_controller_fifo_flush(i3c_inst);
 	nct_i3c_mutex_unlock(dev);
 
 	return ret;
@@ -1574,7 +2378,8 @@ static int nct_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *payl
 	/* Write CCC command */
 	nct_i3c_status_clear_all(i3c_inst);
 	nct_i3c_errwarn_clear_all(i3c_inst);
-	xfered_len = nct_i3c_xfer_write_fifo(i3c_inst, &payload->ccc.id, 1, payload->ccc.data_len > 0);
+	xfered_len =
+		nct_i3c_xfer_write_fifo(i3c_inst, &payload->ccc.id, 1, payload->ccc.data_len > 0);
 	if (xfered_len < 0) {
 		LOG_ERR("CCC[0x%02x] %s command error (%d)", payload->ccc.id,
 			i3c_ccc_is_payload_broadcast(payload) ? "broadcast" : "direct", ret);
@@ -1603,8 +2408,8 @@ static int nct_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *payl
 	}
 
 	/* Wait message transfer complete */
-	if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE), NCT_I3C_CHK_TIMEOUT_US,
-		     NULL) == false) {
+	if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE), I3C_CHK_TIMEOUT_US, NULL) ==
+	    false) {
 		ret = -ETIMEDOUT;
 		LOG_DBG("Check complete timeout");
 		goto out_do_ccc;
@@ -1622,11 +2427,11 @@ static int nct_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *payl
 			struct i3c_ccc_target_payload *tgt_payload =
 				&payload->targets.payloads[idx];
 
-			bool is_read = (tgt_payload->rnw == 1U);
+			bool is_rx = (tgt_payload->rnw == 1U);
 
 			xfered_len = nct_i3c_do_one_xfer(
 				dev, tgt_payload->addr, NCT_I3C_MCTRL_TYPE_I3C, tgt_payload->data,
-				tgt_payload->data_len, is_read, true, false, false);
+				tgt_payload->data_len, is_rx, true, false, false);
 			if (xfered_len < 0) {
 				LOG_ERR("CCC[0x%02x] target payload error (%d)", payload->ccc.id,
 					ret);
@@ -1664,7 +2469,6 @@ static void nct_i3c_ibi_work(struct k_work *work)
 	struct i3c_ibi_work *i3c_ibi_work = CONTAINER_OF(work, struct i3c_ibi_work, work);
 	const struct device *dev = i3c_ibi_work->controller;
 	struct nct_i3c_data *data = dev->data;
-	struct i3c_dev_attached_list *dev_list = &data->common.attached_dev;
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
 	struct i3c_device_desc *target = NULL;
 	uint32_t ibitype, ibiaddr;
@@ -1674,8 +2478,7 @@ static void nct_i3c_ibi_work(struct k_work *work)
 
 	if (nct_i3c_state_get(i3c_inst) != MSTATUS_STATE_TGTREQ) {
 		LOG_DBG("IBI work %p running not because of IBI", work);
-		LOG_ERR("MSTATUS 0x%08x MERRWARN 0x%08x", i3c_inst->MSTATUS,
-			i3c_inst->MERRWARN);
+		LOG_ERR("MSTATUS 0x%08x MERRWARN 0x%08x", i3c_inst->MSTATUS, i3c_inst->MERRWARN);
 
 		nct_i3c_request_emit_stop(i3c_inst);
 
@@ -1686,8 +2489,8 @@ static void nct_i3c_ibi_work(struct k_work *work)
 	nct_i3c_request_auto_ibi(i3c_inst);
 
 	/* Wait for target to win address arbitration (ibitype and ibiaddr) */
-	if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_IBIWON), NCT_I3C_CHK_TIMEOUT_US,
-		     NULL) == false) {
+	if (WAIT_FOR(IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_IBIWON), I3C_CHK_TIMEOUT_US, NULL) ==
+	    false) {
 		LOG_ERR("IBI work, IBIWON timeout");
 
 		goto out_ibi_work;
@@ -1698,11 +2501,19 @@ static void nct_i3c_ibi_work(struct k_work *work)
 
 	switch (ibitype) {
 	case MSTATUS_IBITYPE_IBI:
-		target = i3c_dev_list_i3c_addr_find(dev_list, (uint8_t)ibiaddr);
+		target = i3c_dev_list_i3c_addr_find(dev, (uint8_t)ibiaddr);
 		if (target != NULL) {
 			ret = nct_i3c_xfer_read_fifo(i3c_inst, &payload[0], sizeof(payload));
 			if (ret >= 0) {
 				payload_sz = (size_t)ret;
+if (payload_sz != 1) {
+	LOG_ERR("IBI payload size = %u", payload_sz);
+}
+
+if (payload[0] != 0xAE) {
+	LOG_ERR("IBI payload = %02X", payload[0]);
+}
+
 			} else {
 				LOG_ERR("Error reading IBI payload");
 
@@ -1715,16 +2526,20 @@ static void nct_i3c_ibi_work(struct k_work *work)
 			nct_i3c_ibi_respond_nack(i3c_inst);
 		}
 		break;
+
 	case MSTATUS_IBITYPE_HJ:
 		nct_i3c_ibi_respond_ack(i3c_inst);
 		nct_i3c_request_emit_stop(i3c_inst);
 		break;
+
 	case MSTATUS_IBITYPE_CR:
 		LOG_DBG("Controller role handoff not supported");
 		nct_i3c_ibi_respond_nack(i3c_inst);
 		nct_i3c_request_emit_stop(i3c_inst);
 		break;
+
 	default:
+		/* Intentionally left empty */
 		break;
 	}
 
@@ -1750,14 +2565,17 @@ static void nct_i3c_ibi_work(struct k_work *work)
 		/* Finishing the IBI transaction */
 		nct_i3c_request_emit_stop(i3c_inst);
 		break;
+
 	case MSTATUS_IBITYPE_HJ:
 		if (i3c_ibi_work_enqueue_hotjoin(dev) != 0) {
 			LOG_ERR("Error enqueue IBI HJ work");
 		}
 		break;
+
 	case MSTATUS_IBITYPE_CR:
 		/* Not supported, for future use. */
 		break;
+
 	default:
 		break;
 	}
@@ -1772,6 +2590,9 @@ out_ibi_work:
 }
 
 /* Set local IBI information to IBIRULES register */
+#define NCT_I3C_IBIRULES_ADDR_MSK   0x3F
+#define NCT_I3C_IBIRULES_ADDR_SHIFT 0x6
+
 static void nct_i3c_ibi_rules_setup(struct nct_i3c_data *data, struct i3c_reg *i3c_inst)
 {
 	uint32_t ibi_rules;
@@ -1783,10 +2604,10 @@ static void nct_i3c_ibi_rules_setup(struct nct_i3c_data *data, struct i3c_reg *i
 		uint32_t addr_6bit;
 
 		/* Extract the lower 6-bit of target address */
-		addr_6bit = (uint32_t)data->ibi.addr[idx] & IBIRULES_ADDR_MSK;
+		addr_6bit = (uint32_t)data->ibi.addr[idx] & NCT_I3C_IBIRULES_ADDR_MSK;
 
 		/* Shift into correct place */
-		addr_6bit <<= idx * IBIRULES_ADDR_SHIFT;
+		addr_6bit <<= idx * NCT_I3C_IBIRULES_ADDR_SHIFT;
 
 		/* Put into the temporary IBI Rules register */
 		ibi_rules |= addr_6bit;
@@ -1807,8 +2628,6 @@ static void nct_i3c_ibi_rules_setup(struct nct_i3c_data *data, struct i3c_reg *i
 
 	/* Update the register */
 	i3c_inst->IBIRULES = ibi_rules;
-
-	LOG_DBG("MIBIRULES 0x%08x", ibi_rules);
 }
 
 static int nct_i3c_ibi_enable(const struct device *dev, struct i3c_device_desc *target)
@@ -1843,9 +2662,8 @@ static int nct_i3c_ibi_enable(const struct device *dev, struct i3c_device_desc *
 	/* Disable controller interrupt while we configure IBI rules. */
 	i3c_inst->MINTCLR = BIT(NCT_I3C_MINTCLR_TGTSTART);
 
-	LOG_DBG("IBI enabling for 0x%02x (BCR 0x%02x)", target->dynamic_addr, target->bcr);
-
-	msb = (target->dynamic_addr & BIT(6)) == BIT(6); /* Check addess(7-bit) MSB enable */
+	/* Check addess(7-bit) MSB enable */
+	msb = (target->dynamic_addr & BIT(6)) == BIT(6);
 	has_mandatory_byte = i3c_ibi_has_payload(target);
 
 	/*
@@ -1970,16 +2788,419 @@ static int nct_i3c_ibi_disable(const struct device *dev, struct i3c_device_desc 
 
 	return ret;
 }
+
+static int nct_i3c_target_ibi_raise(const struct device *dev, struct i3c_ibi *request)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *data = dev->data;
+
+	/* The request or the payload were not specific */
+	if ((request == NULL) || ((request->payload_len) && (request->payload == NULL))) {
+		return -EINVAL;
+	}
+
+	/* The I3C was not in target mode or the bus is in HDR mode now */
+	if (!(IS_BIT_SET(i3c_inst->CONFIG, NCT_I3C_CONFIG_TGTENA)) ||
+	    (IS_BIT_SET(i3c_inst->STATUS, NCT_I3C_STATUS_STHDR))) {
+		return -EINVAL;
+	}
+
+	switch (request->ibi_type) {
+	case I3C_IBI_TARGET_INTR:
+		if (IS_BIT_SET(i3c_inst->STATUS, NCT_I3C_STATUS_IBIDIS)) {
+			return -ENOTSUP;
+		}
+
+		if (request->payload_len == 0) {
+			LOG_ERR("IBI invalid payload_len, len: %#x", request->payload_len);
+			return -EINVAL;
+		}
+
+		/* The payload length is too long */
+		if (request->payload_len > I3C_IBI_MAX_PAYLOAD_SIZE) {
+			LOG_ERR("IBI payload too long, use dma instead");
+			return -EINVAL;
+		}
+
+		k_sem_take(&data->target_event_lock_sem, K_FOREVER);
+		set_oper_state(dev, I3C_OP_STATE_IBI);
+
+		/* Mandatory data byte */
+		SET_FIELD(i3c_inst->CTRL, NCT_I3C_CTRL_IBIDATA, request->payload[0]);
+
+		/* Extended data */
+		if (request->payload_len > 1) {
+#ifdef CONFIG_I3C_NCT_DMA
+			int ret;
+
+			ret = nct_i3c_target_do_request_dma(dev, false, &request->payload[1],
+							     request->payload_len - 1, false);
+			if (ret < 0) {
+				LOG_ERR("DMA write request failed");
+				return -EIO;
+			}
+#else
+			int index;
+
+			/* For transaction > 16 bytes, use dma to avoid bus underrun. */
+			for (index = 1; index < (request->payload_len - 1); index++) {
+				i3c_inst->WDATAB = request->payload[index];
+			}
+
+			i3c_inst->WDATABE = request->payload[index];
+#endif
+			SET_FIELD(i3c_inst->IBIEXT1, NCT_I3C_IBIEXT1_CNT, 0);
+			i3c_inst->CTRL |= NCT_I3C_CTRL_EXTDATA;
+		}
+
+		SET_FIELD(i3c_inst->CTRL, NCT_I3C_CTRL_EVENT, CTRL_EVENT_IBI);
+		break;
+
+	case I3C_IBI_CONTROLLER_ROLE_REQUEST:
+		if (IS_BIT_SET(i3c_inst->STATUS, NCT_I3C_STATUS_MRDIS)) {
+			return -ENOTSUP;
+		}
+
+		/*
+		 * The bus controller request was generate only a target with controller mode
+		 * capabilities mode
+		 */
+		if (GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_CTRENA) !=
+		    MCONFIG_CTRENA_CAPABLE) {
+			return -ENOTSUP;
+		}
+
+		k_sem_take(&data->target_event_lock_sem, K_FOREVER);
+		set_oper_state(dev, I3C_OP_STATE_IBI);
+
+		SET_FIELD(i3c_inst->CTRL, NCT_I3C_CTRL_EVENT,
+				   CTRL_EVENT_CNTLR_REQ);
+		break;
+
+	case I3C_IBI_HOTJOIN:
+		if (IS_BIT_SET(i3c_inst->STATUS, NCT_I3C_STATUS_HJDIS)) {
+			return -ENOTSUP;
+		}
+
+		k_sem_take(&data->target_event_lock_sem, K_FOREVER);
+		set_oper_state(dev, I3C_OP_STATE_IBI);
+
+		i3c_inst->CONFIG &= ~BIT(NCT_I3C_CONFIG_TGTENA);
+		SET_FIELD(i3c_inst->CTRL, NCT_I3C_CTRL_EVENT, CTRL_EVENT_HJ);
+		i3c_inst->CONFIG |= BIT(NCT_I3C_CONFIG_TGTENA);
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
 #endif /* CONFIG_I3C_USE_IBI */
+
+static inline int nct_i3c_target_MATCHED_handler(const struct device *dev)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *data = dev->data;
+	const struct i3c_target_callbacks *target_cb =
+		(data->target_config != NULL) ? data->target_config->callbacks : NULL;
+	enum nct_i3c_oper_state oper_state = get_oper_state(dev);
+	int ret = 0;
+	uint32_t int_status = i3c_inst->STATUS;
+
+#ifdef CONFIG_I3C_NCT_DMA
+	if (oper_state != I3C_OP_STATE_IBI) {
+		/* The current bus request is an SDR mode read or write */
+		if (IS_BIT_SET(int_status, NCT_I3C_STATUS_STREQRD)) {
+			/* SDR read request */
+			set_oper_state(dev, I3C_OP_STATE_RD);
+			ret = 1;
+
+			/*
+			 * It will be too late to enable pdma here, use target_tx_write() to
+			 * write tx data into fifo before controller send read request.
+			 */
+#if CONFIG_I3C_TARGET_BUFFER_MODE
+			/* Emit read request callback */
+			if ((target_cb != NULL) && (target_cb->buf_read_requested_cb != NULL)) {
+				target_cb->buf_read_requested_cb(data->target_config, NULL, NULL,
+								 NULL);
+			}
+#endif
+		} else if (IS_BIT_SET(int_status, NCT_I3C_STATUS_STREQWR)) {
+			/* SDR write request */
+			set_oper_state(dev, I3C_OP_STATE_WR);
+			ret = 1;
+
+			/* Emit write request callback */
+			if ((target_cb != NULL) && (target_cb->write_requested_cb != NULL)) {
+				target_cb->write_requested_cb(data->target_config);
+			}
+		}
+	}
+#else
+	if (oper_state != I3C_OP_STATE_IBI) {
+		if (IS_BIT_SET(int_status, NCT_I3C_STATUS_STREQRD)) {
+			/* SDR read request */
+			set_oper_state(dev, I3C_OP_STATE_RD);
+			ret = 1;
+
+			/*
+			 * It will be too late to fill in buffer and write to fifo here, use write
+			 * request to notify target to prepare tx data with target_tx_write()
+			 * before controller send read request.
+			 */
+#ifndef CONFIG_I3C_TARGET_BUFFER_MODE
+			/* Emit read request callback. */
+			if ((target_cb != NULL) && (target_cb->read_requested_cb != NULL)) {
+				target_cb->read_requested_cb(data->target_config, data->tx_buf);
+			}
+#endif
+
+			/* Fill tx FIFO */
+			if (data->tx_len) {
+				ret = nct_i3c_xfer_target_write_fifo(i3c_inst, data->tx_buf,
+								      data->tx_len, false);
+				if (ret < 0) {
+					LOG_ERR("Write tx FIFO failed");
+				}
+			} else {
+				LOG_ERR("No tx data");
+				ret = -EINVAL;
+			}
+
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+			/* Emit buffer read request callback */
+			if ((target_cb != NULL) && (target_cb->buf_read_requested_cb != NULL)) {
+				target_cb->buf_read_requested_cb(data->target_config, NULL, NULL,
+								 NULL);
+			}
+#endif
+		} else if (IS_BIT_SET(int_status, NCT_I3C_STATUS_STREQWR)) {
+			/* SDR write request */
+			set_oper_state(dev, I3C_OP_STATE_WR);
+			ret = 1;
+
+			/* Emit write request callback */
+			if ((target_cb != NULL) && (target_cb->write_requested_cb != NULL)) {
+				target_cb->write_requested_cb(data->target_config);
+			}
+
+			/* Fill write data to rx buffer */
+			ret = nct_i3c_xfer_target_read_fifo(i3c_inst, data->rx_buf);
+			if (ret < 0) {
+				LOG_ERR("Read rx FIFO failed");
+			} else {
+				data->rx_len = ret;
+			}
+		}
+	}
+#endif
+
+	/*
+	 * If CONFIG.MATCHSS=1, MATCHED bit must remain 1 to detect next start
+	 * or stop.
+	 *
+	 * Clear the status bit in STOP or START handler.
+	 */
+	if (IS_BIT_SET(i3c_inst->CONFIG, NCT_I3C_CONFIG_MATCHSS)) {
+		i3c_inst->INTCLR = BIT(NCT_I3C_INTCLR_MATCHED);
+	} else {
+		i3c_inst->STATUS = BIT(NCT_I3C_STATUS_MATCHED);
+	}
+
+	return ret;
+}
+
+static inline void nct_i3c_target_STOP_handler(const struct device *dev)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *data = dev->data;
+	const struct i3c_target_callbacks *target_cb =
+		(data->target_config != NULL) ? data->target_config->callbacks : NULL;
+	enum nct_i3c_oper_state oper_state = get_oper_state(dev);
+
+	if (IS_BIT_SET(i3c_inst->INTMASKED, NCT_I3C_INTMASKED_START)) {
+		/* Clear the status bit */
+		i3c_inst->STATUS = BIT(NCT_I3C_STATUS_START);
+	}
+
+	/*
+	 * The end of xfer is a STOP.
+	 * For write request: check whether rx fifo count is 0.
+	 * For read request: disable the pdma operation.
+	 */
+#ifdef CONFIG_I3C_NCT_DMA
+	if ((oper_state == I3C_OP_STATE_WR) || (oper_state == I3C_OP_STATE_RD)) {
+		if (nct_i3c_target_xfer_end_handle_dma_v2(dev, oper_state) != 0) {
+			LOG_ERR("xfer end handle failed after stop, op state=%d", oper_state);
+		}
+	} else if (oper_state == I3C_OP_STATE_IBI) {
+		if (GET_FIELD(i3c_inst->DATACTRL, NCT_I3C_DATACTRL_TXCOUNT) == 0) {
+			nct_i3c_target_dma_off(dev, false);
+		}
+	} else if (oper_state == I3C_OP_STATE_CCC) {
+		if (nct_i3c_target_xfer_end_handle_dma_v2(dev, oper_state) != 0) {
+			LOG_ERR("xfer end handle failed after stop, op state=%d", oper_state);
+		}
+
+		i3c_inst->STATUS = BIT(NCT_I3C_STATUS_CCC);
+		i3c_inst->INTSET = BIT(NCT_I3C_INTSET_CCC);
+	} else {
+		/* Check RXPEND */
+		if (IS_BIT_SET(i3c_inst->STATUS, NCT_I3C_STATUS_RXPEND) && !(data->tx_valid)) {
+			nct_i3c_target_rx_fifo_flush(i3c_inst);
+		}
+	}
+#else
+	if ((oper_state == I3C_OP_STATE_WR) || (oper_state == I3C_OP_STATE_RD)) {
+		if (nct_i3c_target_xfer_end_handle(dev, oper_state) != 0) {
+			LOG_ERR("xfer end handle failed after stop, op state=%d", oper_state);
+		}
+	}
+#endif
+
+	/* Clear the status bit */
+	i3c_inst->STATUS = BIT(NCT_I3C_STATUS_STOP);
+
+	/* Notify upper layer a STOP condition received */
+	if ((target_cb != NULL) && (target_cb->stop_cb != NULL)) {
+		target_cb->stop_cb(data->target_config);
+	}
+
+	set_oper_state(dev, I3C_OP_STATE_IDLE);
+}
+
+static inline void nct_i3c_target_START_handler(const struct device *dev)
+{
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	enum nct_i3c_oper_state oper_state = get_oper_state(dev); /* Entry operation state */
+
+	/* The end of xfer is a Sr */
+	if ((oper_state == I3C_OP_STATE_WR) || (oper_state == I3C_OP_STATE_RD)) {
+		/* Use entry operation state to handle the xfer end */
+#ifdef CONFIG_I3C_NCT_DMA
+		if (nct_i3c_target_xfer_end_handle_dma(dev, oper_state) == -ETIMEDOUT) {
+			LOG_ERR("xfer end handle failed after start, op state=%d", oper_state);
+
+			set_oper_state(dev, I3C_OP_STATE_IDLE);
+		}
+#else
+		if (nct_i3c_target_xfer_end_handle(dev, oper_state) != 0) {
+			LOG_ERR("xfer end handle failed after stop, op state=%d", oper_state);
+		}
+#endif
+	}
+
+	/* Clear the status bit */
+	i3c_inst->STATUS = BIT(NCT_I3C_STATUS_START);
+}
+
+static void nct_i3c_target_isr(const struct device *dev)
+{
+	struct nct_i3c_data *data = dev->data;
+	struct i3c_config_target *config_target = &data->config_target;
+	struct i3c_target_config *target_config = data->target_config;
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	uint32_t intmask = i3c_inst->INTMASKED;
+
+	while (intmask != 0) {
+#ifndef CONFIG_I3C_NCT_DMA
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_RXPEND)) {
+			/* Flush rx and tx FIFO */
+			nct_i3c_target_rx_fifo_flush(i3c_inst);
+			nct_i3c_target_tx_fifo_flush(i3c_inst);
+		}
+#endif
+
+		/* Check STOP detected */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_STOP)) {
+			nct_i3c_target_STOP_handler(dev);
+		}
+
+		/* Check START or Sr detected */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_START)) {
+			nct_i3c_target_START_handler(dev);
+		}
+
+		/* Check incoming header matched target dynamic address */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_MATCHED)) {
+			nct_i3c_target_MATCHED_handler(dev);
+		}
+
+		/* Check error or warning has occurred */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_ERRWARN)) {
+			if (i3c_inst->ERRWARN == 0x100) {
+				LOG_DBG("ERRWARN %x", i3c_inst->ERRWARN);
+			}
+			else {
+				LOG_ERR("ERRWARN %x", i3c_inst->ERRWARN);
+			}
+
+			i3c_inst->ERRWARN = i3c_inst->ERRWARN;
+		}
+
+		/* Check dynamic address changed */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_DACHG)) {
+			i3c_inst->STATUS = BIT(NCT_I3C_STATUS_DACHG);
+			if (IS_BIT_SET(i3c_inst->DYNADDR, NCT_I3C_DYNADDR_DAVALID)) {
+				if (target_config != NULL) {
+					config_target->dynamic_addr = GET_FIELD(
+						i3c_inst->DYNADDR, NCT_I3C_DYNADDR_DADDR);
+				}
+			}
+		}
+
+		/* CCC 'not' automatically handled was received */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_CCC)) {
+			set_oper_state(dev, I3C_OP_STATE_CCC);
+			i3c_inst->INTCLR = BIT(NCT_I3C_INTCLR_CCC); /* W1C */
+		}
+
+		/* HDR command, address match */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_DDRMATCHED)) {
+			i3c_inst->STATUS = BIT(NCT_I3C_STATUS_DDRMATCH);
+		}
+
+		/* CCC handled (handled by IP) */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_CHANDLED)) {
+			i3c_inst->STATUS = BIT(NCT_I3C_STATUS_CHANDLED);
+		}
+
+		/* Event requested. IBI, hot-join, bus control */
+		if (IS_BIT_SET(intmask, NCT_I3C_INTMASKED_EVENT)) {
+			i3c_inst->STATUS = BIT(NCT_I3C_STATUS_EVENT);
+			if (GET_FIELD(i3c_inst->STATUS, NCT_I3C_STATUS_EVDET) ==
+			    STATUS_EVDET_REQ_SENT_ACKED) {
+				k_sem_give(&data->target_event_lock_sem);
+			}
+		}
+
+		/* Check mask again, flags may be set when handling */
+		intmask = i3c_inst->INTMASKED;
+	}
+
+	/*
+	 * Secondary controller (Controller register).
+	 * Check I3C now bus controller.
+	 * Disable target mode if target switch to controller mode success.
+	 */
+	if (IS_BIT_SET(i3c_inst->MINTMASKED, NCT_I3C_MINTMASKED_NOWMASTER)) {
+		i3c_inst->MSTATUS = BIT(NCT_I3C_MSTATUS_NOWCNTLR); /* W1C */
+		i3c_inst->CONFIG &= ~BIT(NCT_I3C_CONFIG_TGTENA);   /* Disable target mode */
+	}
+}
 
 static void nct_i3c_isr(const struct device *dev)
 {
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
-	uint8_t ctlr_mode;
 
-	ctlr_mode = GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_CTRENA);
-
-	if (ctlr_mode == MCONFIG_CTRENA_ON) {
+	if (IS_BIT_SET(i3c_inst->CONFIG, NCT_I3C_CONFIG_TGTENA)) {
+		/* Target mode */
+		nct_i3c_target_isr(dev);
+	} else if (GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_CTRENA) ==
+		   MCONFIG_CTRENA_ON) {
+		/* Controller mode */
 #ifdef CONFIG_I3C_NCT_DMA
 		if (IS_BIT_SET(i3c_inst->MSTATUS, NCT_I3C_MSTATUS_COMPLETE)) {
 			/* Clear COMPLETE status */
@@ -2001,10 +3222,11 @@ static void nct_i3c_isr(const struct device *dev)
 			/* Disable further target initiated IBI interrupt */
 			i3c_inst->MINTCLR = BIT(NCT_I3C_MINTCLR_TGTSTART);
 
-			/* Clear TGTSTART interrupt */
+			/* Clear SLVSTART interrupt */
 			i3c_inst->MSTATUS = BIT(NCT_I3C_MSTATUS_TGTSTART);
 
 			/* Handle IBI in workqueue */
+
 			ret = i3c_ibi_work_enqueue_cb(dev, nct_i3c_ibi_work);
 			if (ret < 0) {
 				LOG_ERR("Enqueuing ibi work fail, ret %d", ret);
@@ -2012,6 +3234,8 @@ static void nct_i3c_isr(const struct device *dev)
 			}
 		}
 #endif /* CONFIG_I3C_USE_IBI */
+	} else {
+		LOG_ERR("Unknown mode");
 	}
 }
 
@@ -2038,7 +3262,8 @@ static int nct_i3c_get_scl_config(struct nct_i3c_timing_cfg *cfg, uint32_t i3c_s
 		return -EINVAL;
 	}
 
-	/* PPBAUD(pp-high) = number of i3c source clock period in one I3C_SCL high
+	/*
+	 * PPBAUD(pp-high) = number of i3c source clock period in one I3C_SCL high
 	 * period for I3C push-pull operation.
 	 * For example, 48Mhz = 20.8 ns, 96Mhz = 10.4 ns
 	 */
@@ -2060,7 +3285,8 @@ static int nct_i3c_get_scl_config(struct nct_i3c_timing_cfg *cfg, uint32_t i3c_s
 		return -EINVAL;
 	}
 
-	/* 0x0 = one source clock period for pp-high
+	/*
+	 * 0x0 = one source clock period for pp-high
 	 * 0x1 = two source clock period for pp-high
 	 * 0x2 = three source clock period for pp-high
 	 * ...
@@ -2077,7 +3303,8 @@ static int nct_i3c_get_scl_config(struct nct_i3c_timing_cfg *cfg, uint32_t i3c_s
 		return -EINVAL;
 	}
 
-	/* odbaud = Number of PPBAUD periods (minus 1) in one I3C_SCL low period
+	/*
+	 * odbaud = Number of PPBAUD periods (minus 1) in one I3C_SCL low period
 	 * for I3C open-drain operation.
 	 */
 
@@ -2117,7 +3344,8 @@ static int nct_i3c_get_scl_config(struct nct_i3c_timing_cfg *cfg, uint32_t i3c_s
 			div++;
 		}
 
-		/* I2CBAUD = scl-high + scl-low
+		/*
+		 * I2CBAUD = scl-high + scl-low
 		 * (I2CBAUD >> 1) + 1 ==> scl-high
 		 * (I2CBAUD >> 1) + 1 + lsb bit ==> scl-low
 		 */
@@ -2145,8 +3373,9 @@ static int nct_i3c_freq_init(const struct device *dev)
 	const struct nct_i3c_config *config = dev->config;
 	struct nct_i3c_data *data = dev->data;
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
-	const struct device *const clk_dev = DEVICE_DT_GET(DT_NODELABEL(pcc));
+	const struct device *const clk_dev = DEVICE_DT_GET(NCT_PCC_NODE);
 	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
+
 	uint32_t scl_pp = ctrl_config->scl.i3c;
 	uint32_t scl_od = config->clocks.i3c_od_scl_hz;
 	uint32_t scl_i2c = ctrl_config->scl.i2c;
@@ -2154,7 +3383,7 @@ static int nct_i3c_freq_init(const struct device *dev)
 	uint32_t i3c_freq_rate;
 	int ret;
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t)config->clk_cfg,
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)config->clk_cfg,
 				     &i3c_freq_rate);
 	if (ret != 0x0) {
 		LOG_ERR("Get I3C source clock fail %d", ret);
@@ -2170,17 +3399,15 @@ static int nct_i3c_freq_init(const struct device *dev)
 	LOG_DBG("hdr: %d", ctrl_config->supported_hdr);
 
 	if (i3c_freq_rate == I3C_CLK_FREQ_48_MHZ) {
-		timing_cfg = nct_def_speed_cfg[NCT_I3C_CLK_FREQ_48MHZ];
+		timing_cfg = nct_def_speed_cfg[I3C_CLK_FREQ_48MHZ];
 	} else if (i3c_freq_rate == I3C_CLK_FREQ_96_MHZ) {
-		timing_cfg = nct_def_speed_cfg[NCT_I3C_CLK_FREQ_96MHZ];
+		timing_cfg = nct_def_speed_cfg[I3C_CLK_FREQ_96MHZ];
 	} else {
-		LOG_ERR("Unsupported i3c freq for %s. freq rate: %d",
-				dev->name, i3c_freq_rate);
+		LOG_ERR("Unsupported i3c freq for %s. freq rate: %d", dev->name, i3c_freq_rate);
 		return -EINVAL;
 	}
 
-	ret = nct_i3c_get_scl_config(&timing_cfg, i3c_freq_rate, scl_pp,
-			scl_od, scl_i2c);
+	ret = nct_i3c_get_scl_config(&timing_cfg, i3c_freq_rate, scl_pp, scl_od, scl_i2c);
 	if (ret != 0x0) {
 		LOG_ERR("Adjust I3C frequency fail");
 		return -EINVAL;
@@ -2191,32 +3418,39 @@ static int nct_i3c_freq_init(const struct device *dev)
 	SET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_PPLOW, timing_cfg.pplow);
 	SET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_ODBAUD, timing_cfg.odbaud);
 	SET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_I2CBAUD, timing_cfg.i2c_baud);
+
 	if (timing_cfg.odhpp != 0) {
-		i3c_inst->MCONFIG |= BIT(NCT_I3C_MCONFIG_ODHPP);
+		i3c_inst->MCONFIG |= NCT_I3C_MCONFIG_ODHPP;
 	} else {
-		i3c_inst->MCONFIG &= ~BIT(NCT_I3C_MCONFIG_ODHPP);
+		i3c_inst->MCONFIG &= ~NCT_I3C_MCONFIG_ODHPP;
 	}
 
-	LOG_DBG("ppbaud: %d", GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_PPBAUD));
-	LOG_DBG("odbaud: %d", GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_ODBAUD));
-	LOG_DBG("pplow: %d", GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_PPLOW));
-	LOG_DBG("odhpp: %d", IS_BIT_SET(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_ODHPP));
-	LOG_DBG("i2c_baud: %d", GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_I2CBAUD));
+	LOG_DBG("ppbaud: %d", (int)GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_PPBAUD));
+	LOG_DBG("odbaud: %d", (int)GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_ODBAUD));
+	LOG_DBG("pplow: %d", (int)GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_PPLOW));
+	LOG_DBG("odhpp: %d", !!(i3c_inst->MCONFIG & NCT_I3C_MCONFIG_ODHPP));
+	LOG_DBG("i2c_baud: %d",
+		(int)GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_I2CBAUD));
 
 	return 0;
 }
 
-static int nct_i3c_cntlr_init(const struct device *dev)
+static int nct_i3c_controller_init(const struct device *dev, uint8_t mode)
 {
 	const struct nct_i3c_config *config = dev->config;
+	struct nct_i3c_data *data = dev->data;
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
-	const struct device *const clk_dev = DEVICE_DT_GET(DT_NODELABEL(pcc));
+	const struct device *const clk_dev = DEVICE_DT_GET(NCT_PCC_NODE);
 	uint32_t i3c_freq_rate;
 	uint8_t bamatch;
 	int ret;
 
-	/* Reset I3C module */
-	nct_i3c_reset_module(dev);
+	/* Enable Controller */
+	SET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_CTRENA, mode);
+	/* No need to set the MCONFIG register in off mode */
+	if (mode == MCONFIG_CTRENA_OFF) {
+		return 0;
+	}
 
 	/* Disable all interrupts */
 	nct_i3c_interrupt_all_disable(i3c_inst);
@@ -2226,17 +3460,15 @@ static int nct_i3c_cntlr_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	/* Enable main controller mode */
-	SET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_CTRENA, MCONFIG_CTRENA_ON);
 	/* Enable open-drain stop */
 	i3c_inst->MCONFIG |= BIT(NCT_I3C_MCONFIG_ODSTOP);
 	/* Enable timeout */
 	i3c_inst->MCONFIG &= ~BIT(NCT_I3C_MCONFIG_DISTO);
 	/* Flush tx and tx FIFO buffer */
-	nct_i3c_fifo_flush(i3c_inst);
+	nct_i3c_controller_fifo_flush(i3c_inst);
 
 	/* Set bus available match value in target register */
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t)config->clk_cfg,
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)config->clk_cfg,
 				     &i3c_freq_rate);
 	LOG_DBG("I3C_CLK_FREQ: %d", i3c_freq_rate);
 
@@ -2246,17 +3478,140 @@ static int nct_i3c_cntlr_init(const struct device *dev)
 	}
 
 	bamatch = DIV_ROUND_UP(i3c_freq_rate, MHZ(1));
-	LOG_DBG("BAMATCH: %d", bamatch);
-
 	SET_FIELD(i3c_inst->CONFIG, NCT_I3C_CONFIG_BAMATCH, bamatch);
 
+	if (mode == MCONFIG_CTRENA_ON) {
+		struct i3c_config_target *config_target = &data->config_target;
+		config_target->enable = false;
+	}
+
 	return 0;
+}
+
+#define NCT_I3C_CONFIG_HDRCMD_RD_FROM_FIFO   0x0
+#define NCT_I3C_CONFIG_HDRCMD_RD_FROM_HDRCMD 0x1
+static int nct_i3c_target_init(const struct device *dev)
+{
+	const struct nct_i3c_config *config = dev->config;
+	struct nct_i3c_data *data = dev->data;
+	struct i3c_config_target *config_target = &data->config_target;
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	const struct device *const clk_dev = DEVICE_DT_GET(NCT_PCC_NODE);
+	uint32_t i3c_freq_rate;
+	uint8_t bamatch;
+	int ret;
+	uint64_t pid;
+
+	/* Make sure Slave Enable is not set when setting up target */
+	i3c_inst->CONFIG &= ~BIT(NCT_I3C_CONFIG_TGTENA);
+
+	/* Set bus available match value in target register */
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)config->clk_cfg,
+				     &i3c_freq_rate);
+	LOG_DBG("I3C_CLK_FREQ: %d", i3c_freq_rate);
+
+	if (ret != 0x0) {
+		LOG_ERR("Get I3C source clock fail %d", ret);
+		return -EINVAL;
+	}
+
+	bamatch = DIV_ROUND_UP(i3c_freq_rate, MHZ(1));
+	SET_FIELD(i3c_inst->CONFIG, NCT_I3C_CONFIG_BAMATCH, bamatch);
+
+	/* Set Provisional ID */
+	pid = config_target->pid;
+	/* PID[47:33] MIPI manufacturer ID */
+	SET_FIELD(i3c_inst->VENDORID, NCT_I3C_VENDORID_VID,
+			   (uint32_t)GET_PID_VENDOR_ID(pid));
+
+	/* PID[32] Vendor fixed value(0) or random value(1) */
+	if (config_target->pid_random) {
+		i3c_inst->CONFIG |= BIT(NCT_I3C_CONFIG_IDRAND);
+	} else {
+		i3c_inst->CONFIG &= ~BIT(NCT_I3C_CONFIG_IDRAND);
+	}
+
+	/* PID[31:0] vendor fixed value */
+	i3c_inst->PARTNO = (uint32_t)GET_PID_PARTNO(pid);
+
+	LOG_DBG("pid: %#llx", pid);
+	LOG_DBG("vendro id: %#x", (uint32_t)GET_PID_VENDOR_ID(pid));
+	LOG_DBG("id type: %d", (uint32_t)GET_PID_ID_TYP(pid));
+	LOG_DBG("partno: %#x", (uint32_t)GET_PID_PARTNO(pid));
+
+	SET_FIELD(i3c_inst->IDEXT, NCT_I3C_IDEXT_DCR, config_target->dcr);
+	SET_FIELD(i3c_inst->IDEXT, NCT_I3C_IDEXT_BCR, config_target->bcr);
+	SET_FIELD(i3c_inst->CONFIG, NCT_I3C_CONFIG_SADDR, config_target->static_addr);
+	//i3c_inst->CONFIG &= ~BIT(NCT_I3C_CONFIG_HDRCMD);
+	i3c_inst->CONFIG |= BIT(NCT_I3C_CONFIG_HDRCMD);
+	SET_FIELD(i3c_inst->MAXLIMITS, NCT_I3C_MAXLIMITS_MAXRD,
+			   (config_target->max_read_len) & 0xfff);
+	SET_FIELD(i3c_inst->MAXLIMITS, NCT_I3C_MAXLIMITS_MAXWR,
+			   (config_target->max_write_len) & 0xfff);
+
+	LOG_DBG("static addr: %#x", config_target->static_addr);
+	LOG_DBG("max read len: %d", config_target->max_read_len);
+	LOG_DBG("max write len: %d", config_target->max_write_len);
+
+	/* Ignore DA and detect all START and STOP */
+	i3c_inst->CONFIG &= ~BIT(NCT_I3C_CONFIG_MATCHSS);
+
+	/* Enable the target interrupt events */
+	nct_i3c_enable_target_interrupt(dev, true);
+
+	/* Target mode enable */
+	i3c_inst->CONFIG |= BIT(NCT_I3C_CONFIG_TGTENA);
+
+	config_target->enable = true;
+
+	/* setup rx dma in advance to prevent data loss for RX FIFO is too small */
+	init_i3c_slave_rx_payload(dev);
+	nct_i3c_target_rx_read(dev);
+
+	/* Flush target rx and tx fifo */
+	nct_i3c_target_tx_fifo_flush(i3c_inst);
+	nct_i3c_target_rx_fifo_flush(i3c_inst);
+
+	return 0;
+}
+
+static void nct_i3c_dev_init(const struct device *dev)
+{
+	struct nct_i3c_data *data = dev->data;
+	struct i3c_config_controller *config_cntlr = &data->common.ctrl_config;
+	struct i3c_config_target *config_target = &data->config_target;
+
+	/* Reset I3C module */
+	nct_i3c_reset_module(dev);
+
+	if (I3C_BCR_DEVICE_ROLE(config_target->bcr) == I3C_BCR_DEVICE_ROLE_I3C_CONTROLLER_CAPABLE) {
+		if (config_cntlr->is_secondary) {
+			LOG_DBG("Secondary controller");
+			/* Set Secondary controller boot as a target */
+			nct_i3c_controller_init(dev, MCONFIG_CTRENA_CAPABLE);
+
+			/* Set I3C target */
+			nct_i3c_target_init(dev);
+		} else {
+			LOG_DBG("Primary controller");
+			/* Set Primary controller */
+			nct_i3c_controller_init(dev, MCONFIG_CTRENA_ON);
+		}
+	} else {
+		LOG_DBG("I3C target");
+		/* Disable I3C controller */
+		nct_i3c_controller_init(dev, MCONFIG_CTRENA_OFF);
+
+		/* Set I3C target */
+		nct_i3c_target_init(dev);
+	}
 }
 
 static int nct_i3c_configure(const struct device *dev, enum i3c_config_type type, void *config)
 {
 	struct nct_i3c_data *dev_data = dev->data;
 	struct i3c_config_controller *cntlr_cfg = config;
+	struct i3c_config_target *config_target;
 
 	if (type == I3C_CONFIG_CONTROLLER) {
 		/*
@@ -2271,11 +3626,20 @@ static int nct_i3c_configure(const struct device *dev, enum i3c_config_type type
 		(void)memcpy(&dev_data->common.ctrl_config, cntlr_cfg, sizeof(*cntlr_cfg));
 
 		/* Controller init */
-		return nct_i3c_cntlr_init(dev);
-	} else {
-		LOG_ERR("Support controller mode only");
+		return nct_i3c_controller_init(dev, MCONFIG_CTRENA_ON);
+	} else if (type == I3C_CONFIG_TARGET) {
+		config_target = config;
+
+		if (config_target->pid == 0) {
+			LOG_ERR("configure target failed");
 		return -EINVAL;
 	}
+
+		nct_i3c_target_init(dev);
+	}
+
+	LOG_ERR("Not supported mode %d", type);
+	return -EINVAL;
 }
 
 static int nct_i3c_config_get(const struct device *dev, enum i3c_config_type type, void *config)
@@ -2288,6 +3652,25 @@ static int nct_i3c_config_get(const struct device *dev, enum i3c_config_type typ
 
 	(void)memcpy(config, &data->common.ctrl_config, sizeof(data->common.ctrl_config));
 
+
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	uint32_t mstatus;
+	uint32_t mintset;
+	uint32_t mintmask;
+
+
+	mstatus = i3c_inst->MSTATUS;
+	mintset = i3c_inst->MINTSET;
+	mintmask = i3c_inst->MINTMASKED;
+
+	if (IS_BIT_SET(mstatus, NCT_I3C_MSTATUS_TGTSTART)) {
+//		IRQ_CONNECT(0x44, 0x03, nct_i3c_isr, dev, 0);
+//		irq_enable(0x44);
+return 2;		
+	} else {
+return 1;
+	}
+
 	return 0;
 }
 
@@ -2296,8 +3679,11 @@ static int nct_i3c_init(const struct device *dev)
 	const struct nct_i3c_config *config = dev->config;
 	struct nct_i3c_data *data = dev->data;
 	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
-	const struct device *const clk_dev = DEVICE_DT_GET(DT_NODELABEL(pcc));
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	const struct device *const clk_dev = DEVICE_DT_GET(NCT_PCC_NODE);
 	int ret;
+
+	LOG_DBG("%s", dev->name);
 
 	/* Check clock device ready */
 	if (!device_is_ready(clk_dev)) {
@@ -2306,7 +3692,7 @@ static int nct_i3c_init(const struct device *dev)
 	}
 
 	/* Set I3C_PD operational */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t)config->clk_cfg);
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on I3C clock fail %d", ret);
 		return ret;
@@ -2319,9 +3705,12 @@ static int nct_i3c_init(const struct device *dev)
 		return ret;
 	}
 
+	/* Lock initial */
 	k_mutex_init(&data->lock_mutex);
 	k_sem_init(&data->sync_sem, 0, 1);
 	k_sem_init(&data->ibi_lock_sem, 1, 1);
+	k_sem_init(&data->target_lock_sem, 1, 1);
+	k_sem_init(&data->target_event_lock_sem, 1, 1);
 
 	ret = i3c_addr_slots_init(dev);
 	if (ret != 0) {
@@ -2329,29 +3718,33 @@ static int nct_i3c_init(const struct device *dev)
 		return ret;
 	}
 
-	ctrl_config->is_secondary = false; /* Currently can only act as primary controller. */
-	ctrl_config->supported_hdr = 0U;   /* HDR mode not supported at the moment. */
+	/* Configure I3C controller */
 	ctrl_config->scl.i3c = config->clocks.i3c_pp_scl_hz;	/* Set I3C frequency */
 	ctrl_config->scl.i2c = config->clocks.i2c_scl_hz;	/* Set I2C frequency */
 
-	ret = nct_i3c_configure(dev, I3C_CONFIG_CONTROLLER, ctrl_config);
-	if (ret != 0) {
-		LOG_ERR("Apply i3c_configure() fail %d", ret);
-		return ret;
-	}
+	/* Initial I3C device as controller or target */
+	nct_i3c_dev_init(dev);
 
 	/* Just in case the bus is not in idle. */
+	if (GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_CTRENA) ==
+	    MCONFIG_CTRENA_ON) {
 	ret = nct_i3c_recover_bus(dev);
 	if (ret != 0) {
 		LOG_ERR("Apply i3c_recover_bus() fail %d", ret);
 		return ret;
 	}
+	}
 
 	/* Configure interrupt */
 	config->irq_config_func(dev);
 
-	/* Check I3C target device exist in device tree */
-	if (config->common.dev_list.num_i3c > 0) {
+	/* Initialize driver status machine */
+	set_oper_state(dev, I3C_OP_STATE_IDLE);
+
+	/* Check I3C is controller mode and target device exist in device tree */
+	if ((config->common.dev_list.num_i3c > 0) &&
+	    (GET_FIELD(i3c_inst->MCONFIG, NCT_I3C_MCONFIG_CTRENA) ==
+	     MCONFIG_CTRENA_ON)) {
 		/* Perform bus initialization */
 		ret = i3c_bus_init(dev, &config->common.dev_list);
 		if (ret != 0) {
@@ -2368,10 +3761,8 @@ static int nct_i3c_i2c_api_configure(const struct device *dev, uint32_t dev_conf
 	return -ENOSYS;
 }
 
-static int nct_i3c_i2c_api_transfer(const struct device *dev,
-				     struct i2c_msg *msgs,
-				     uint8_t num_msgs,
-				     uint16_t addr)
+static int nct_i3c_i2c_api_transfer(const struct device *dev, struct i2c_msg *msgs,
+				     uint8_t num_msgs, uint16_t addr)
 {
 	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
 	uint32_t intmask;
@@ -2381,7 +3772,7 @@ static int nct_i3c_i2c_api_transfer(const struct device *dev,
 	nct_i3c_mutex_lock(dev);
 
 	if (WAIT_FOR((nct_i3c_state_get(i3c_inst) == MSTATUS_STATE_IDLE),
-				NCT_I3C_CHK_TIMEOUT_US, NULL) == false) {
+		     I3C_CHK_TIMEOUT_US, NULL) == false) {
 		LOG_ERR("xfer state error: %d", nct_i3c_state_get(i3c_inst));
 		nct_i3c_mutex_unlock(dev);
 		return -ETIMEDOUT;
@@ -2395,15 +3786,15 @@ static int nct_i3c_i2c_api_transfer(const struct device *dev,
 
 	/* Iterate over all the messages */
 	for (int i = 0; i < num_msgs; i++) {
-		bool is_read = (msgs[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ;
+		bool is_rx = (msgs[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ;
 		bool no_ending = false;
 
 		/*
 		 * Emit start if this is the first message or that
 		 * the RESTART flag is set in message.
 		 */
-		bool emit_start = (i == 0) ||
-				  ((msgs[i].flags & I2C_MSG_RESTART) == I2C_MSG_RESTART);
+		bool emit_start =
+			(i == 0) || ((msgs[i].flags & I2C_MSG_RESTART) == I2C_MSG_RESTART);
 
 		bool emit_stop = (msgs[i].flags & I2C_MSG_STOP) == I2C_MSG_STOP;
 
@@ -2415,9 +3806,8 @@ static int nct_i3c_i2c_api_transfer(const struct device *dev,
 		 * message to be the last byte of a series of write mssages.
 		 * If not, tell the write function not to treat it that way.
 		 */
-		if (!is_read && !emit_stop && ((i + 1) != num_msgs)) {
-			bool next_is_write =
-				(msgs[i + 1].flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE;
+		if (!is_rx && !emit_stop && ((i + 1) != num_msgs)) {
+			bool next_is_write = (msgs[i + 1].flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE;
 			bool next_is_restart =
 				((msgs[i + 1].flags & I2C_MSG_RESTART) == I2C_MSG_RESTART);
 
@@ -2428,13 +3818,13 @@ static int nct_i3c_i2c_api_transfer(const struct device *dev,
 
 #ifdef CONFIG_I3C_NCT_DMA
                 /* Do transfer with target device */
-		xfered_len = nct_i3c_do_one_xfer_dma(dev, addr, NCT_I3C_MCTRL_TYPE_I2C,
-					   msgs[i].buf, msgs[i].len,
-					   is_read, emit_start, emit_stop, no_ending);
+		xfered_len = nct_i3c_do_one_xfer_dma(dev, addr, NCT_I3C_MCTRL_TYPE_I2C, msgs[i].buf,
+						      msgs[i].len, is_rx, emit_start, emit_stop,
+						      no_ending);
 #else
-		xfered_len = nct_i3c_do_one_xfer(dev, addr, NCT_I3C_MCTRL_TYPE_I2C,
-					   msgs[i].buf, msgs[i].len,
-					   is_read, emit_start, emit_stop, no_ending);
+		xfered_len =
+			nct_i3c_do_one_xfer(dev, addr, NCT_I3C_MCTRL_TYPE_I2C, msgs[i].buf,
+					     msgs[i].len, is_rx, emit_start, emit_stop, no_ending);
 #endif
 		if (xfered_len < 0) {
 			LOG_ERR("do xfer fail");
@@ -2465,6 +3855,102 @@ out_xfer_i2c_stop_unlock:
 	return ret;
 }
 
+/*
+ * brief:  I3C target write data to controller.
+ *
+ * param[in] dev       Pointer to controller device driver instance.
+ * param[in] buf       Buffer containing data to be sent or received.
+ *                     The caller must ensure that the buffer is valid until the
+ *                     transaction is completed (STOP or Sr received).
+ * param[in] len       Number of bytes in buf to send or receive.
+ * param[in] hdr_mode  HDR mode.
+ *
+ * return  Number of bytes transferred, or negative if error.
+ */
+static int nct_i3c_target_tx_write(const struct device *dev, uint8_t *buf, uint16_t len,
+				    uint8_t hdr_mode)
+{
+	int ret = 0;
+
+	if ((buf == NULL) || (len == 0)) {
+		LOG_ERR("Data buffer configuration failed");
+		return -EINVAL;
+	}
+
+	if (hdr_mode != 0) {
+		LOG_ERR("HDR not supported");
+		return -ENOSYS;
+	}
+
+#ifdef CONFIG_I3C_NCT_DMA
+	struct nct_i3c_data *data = dev->data;
+	bool is_rx = false;
+	bool no_ending = false;
+
+	data->tx_valid = true;
+
+	ret = nct_i3c_target_do_request_dma(dev, is_rx, buf, len, no_ending);
+	if (ret < 0) {
+		data->tx_valid = false;
+		LOG_ERR("do xfer fail");
+	}
+
+	return ret;
+#else
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct nct_i3c_data *data = dev->data;
+	bool no_ending;
+
+	/* Flush buffer, make sure no dummy data remain. */
+	nct_i3c_target_tx_fifo_flush(i3c_inst);
+
+	/* Tx buffer point to user buffer */
+	data->tx_buf = buf;
+
+	/* Check buffer length */
+	if (len > I3C_FIFO_SIZE) {
+		no_ending = true;
+		data->tx_len = I3C_FIFO_SIZE;
+	} else {
+		no_ending = false;
+		data->tx_len = len;
+	}
+
+	/* Write tx fifo */
+	ret = nct_i3c_xfer_target_write_fifo(i3c_inst, data->tx_buf, data->tx_len, no_ending);
+	if (ret < 0) {
+		LOG_ERR("do xfer fail");
+	} else if (len > ret) {
+		/* Update buffer index */
+		data->tx_buf += ret;
+		data->tx_len = len - ret;
+
+		/* Update remain len */
+		ret = data->tx_len;
+	}
+
+	return ret;
+#endif
+}
+
+static int nct_i3c_target_register(const struct device *dev, struct i3c_target_config *cfg)
+{
+	struct nct_i3c_data *data = dev->data;
+
+	data->target_config = cfg;
+
+	return 0;
+}
+
+static int nct_i3c_target_unregister(const struct device *dev, struct i3c_target_config *cfg)
+{
+	struct nct_i3c_data *data = dev->data;
+
+	data->target_config = NULL;
+
+	return 0;
+}
+
 static const struct i3c_driver_api nct_i3c_driver_api = {
 	.i2c_api.configure = nct_i3c_i2c_api_configure,
 	.i2c_api.transfer = nct_i3c_i2c_api_transfer,
@@ -2476,45 +3962,257 @@ static const struct i3c_driver_api nct_i3c_driver_api = {
 	.do_ccc = nct_i3c_do_ccc,
 	.i3c_device_find = nct_i3c_device_find,
 	.i3c_xfers = nct_i3c_transfer,
+
+	.target_tx_write = nct_i3c_target_tx_write,
+	.target_register = nct_i3c_target_register,
+	.target_unregister = nct_i3c_target_unregister,
 #ifdef CONFIG_I3C_USE_IBI
 	.ibi_enable = nct_i3c_ibi_enable,
 	.ibi_disable = nct_i3c_ibi_disable,
+	.ibi_raise = nct_i3c_target_ibi_raise,
 #endif
 };
 
-#define I3C_NCT_DEVICE(id)                                                                           \
-	PINCTRL_DT_INST_DEFINE(id);                                                                   \
-	static void nct_i3c_config_func_##id(const struct device *dev)                               \
+#define DT_INST_TGT_PID_PROP_OR(id, prop, idx)                                                     \
+	COND_CODE_1(DT_INST_PROP_HAS_IDX(id, prop, idx), (DT_INST_PROP_BY_IDX(id, prop, idx)), (0))
+#define DT_INST_TGT_PID_RAND_PROP_OR(id, prop, idx)                                                \
+	COND_CODE_1(DT_INST_PROP_HAS_IDX(id, prop, idx),                                           \
+		    IS_BIT_SET(DT_INST_PROP_BY_IDX(id, prop, 0), 0), (0))
+
+#define I3C_NCT_DEVICE(inst)                                                         \
+	PINCTRL_DT_INST_DEFINE(inst);                                                              \
+	static void nct_i3c_irq_config_##inst(const struct device *dev)                           \
 	{                                                                                             \
-		IRQ_CONNECT(DT_INST_IRQN(id), DT_INST_IRQ(id, priority), nct_i3c_isr,                \
-			    DEVICE_DT_INST_GET(id), 0);                                               \
-		irq_enable(DT_INST_IRQN(id));                                                         \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), nct_i3c_isr,         \
+			    DEVICE_DT_INST_GET(inst), 0);                                          \
+		irq_enable(DT_INST_IRQN(inst));                                                    \
 	};                                                                                            \
-	static struct i3c_device_desc nct_i3c_device_array_##id[] = I3C_DEVICE_ARRAY_DT_INST(id);    \
-	static struct i3c_i2c_device_desc nct_i3c_i2c_device_array_##id[] =                          \
-		I3C_I2C_DEVICE_ARRAY_DT_INST(id);                                                     \
-	static const struct nct_i3c_config nct_i3c_config_##id = {                                  \
-		.base = (struct i3c_reg *)DT_INST_REG_ADDR(id),                                       \
-		.clk_cfg = DT_INST_PHA(id, clocks, clk_cfg),                                          \
-		.irq_config_func = nct_i3c_config_func_##id,                                         \
-		.common.dev_list.i3c = nct_i3c_device_array_##id,                                    \
-		.common.dev_list.num_i3c = ARRAY_SIZE(nct_i3c_device_array_##id),                    \
-		.common.dev_list.i2c = nct_i3c_i2c_device_array_##id,                                \
-		.common.dev_list.num_i2c = ARRAY_SIZE(nct_i3c_i2c_device_array_##id),                \
-		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),                                         \
-		.clocks.i3c_pp_scl_hz = DT_INST_PROP_OR(id, i3c_scl_hz, 0),                           \
-		.clocks.i3c_od_scl_hz = DT_INST_PROP_OR(id, i3c_od_scl_hz, 0),                        \
-		.clocks.i2c_scl_hz = DT_INST_PROP_OR(id, i2c_scl_hz, 0),                              \
+                                                                                                   \
+	static struct i3c_device_desc nct_i3c_device_array_##inst[] =                             \
+		I3C_DEVICE_ARRAY_DT_INST(inst);                                                    \
+                                                                                                   \
+	static struct i3c_i2c_device_desc nct_i3c_i2c_device_array_##inst[] =                     \
+		I3C_I2C_DEVICE_ARRAY_DT_INST(inst);                                                \
+                                                                                                   \
+	static const struct nct_i3c_config nct_i3c_config_##inst = {                             \
+		.base = (struct i3c_reg *)DT_INST_REG_ADDR(inst),                                  \
+		.clk_cfg = DT_INST_PHA(inst, clocks, clk_cfg),                                     \
+		.irq_config_func = nct_i3c_irq_config_##inst,                                     \
+		.common.dev_list.i3c = nct_i3c_device_array_##inst,                               \
+		.common.dev_list.num_i3c = ARRAY_SIZE(nct_i3c_device_array_##inst),               \
+		.common.dev_list.i2c = nct_i3c_i2c_device_array_##inst,                           \
+		.common.dev_list.num_i2c = ARRAY_SIZE(nct_i3c_i2c_device_array_##inst),           \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                    \
+		.clocks.i3c_pp_scl_hz = DT_INST_PROP_OR(inst, i3c_scl_hz, 0),                      \
+		.clocks.i3c_od_scl_hz = DT_INST_PROP_OR(inst, i3c_od_scl_hz, 0),                   \
+		.clocks.i2c_scl_hz = DT_INST_PROP_OR(inst, i2c_scl_hz, 0),                         \
+		.priv_xfer_pec = DT_INST_PROP_OR(inst, priv_xfer_pec, false), 						\
+		.ibi_append_pec = DT_INST_PROP_OR(inst, ibi_append_pec, false), 					\
 		IF_ENABLED(CONFIG_I3C_NCT_DMA, (                                                     \
-			.pdma_rx = (struct pdma_dsct_reg *)DT_INST_REG_ADDR_BY_IDX(id, 1),            \
-		))                                                                                    \
-		IF_ENABLED(CONFIG_I3C_NCT_DMA, (                                                     \
-			.pdma_tx = (struct pdma_dsct_reg *)DT_INST_REG_ADDR_BY_IDX(id, 2),            \
-		))                                                                                    \
+			.pdma_rx = (struct pdma_dsct_reg *)DT_INST_REG_ADDR_BY_IDX(inst, 1), \
+			.pdma_tx = (struct pdma_dsct_reg *)DT_INST_REG_ADDR_BY_IDX(inst, 2), \
+			)) };                  \
+	static struct nct_i3c_data nct_i3c_data_##inst = {                                       \
+		.common.ctrl_config.is_secondary = DT_INST_PROP_OR(inst, secondary, false),        \
+		.config_target.static_addr = DT_INST_PROP_OR(inst, static_address, 0),             \
+		.config_target.pid = ((uint64_t)DT_INST_TGT_PID_PROP_OR(inst, tgt_pid, 0) << 32) | \
+				     DT_INST_TGT_PID_PROP_OR(inst, tgt_pid, 1),                    \
+		.config_target.pid_random = DT_INST_TGT_PID_RAND_PROP_OR(inst, tgt_pid, 0),        \
+		.config_target.bcr = DT_INST_PROP(inst, bcr),                                      \
+		.config_target.dcr = DT_INST_PROP_OR(inst, dcr, 0),                                \
+		.config_target.max_read_len = DT_INST_PROP_OR(inst, maximum_read, 256),              \
+		.config_target.max_write_len = DT_INST_PROP_OR(inst, maximum_write, 256),            \
+		.config_target.supported_hdr = false,                                              \
 	};                                                                                            \
-	static struct nct_i3c_data nct_i3c_data_##id;                                               \
-	DEVICE_DT_INST_DEFINE(id, nct_i3c_init, NULL, &nct_i3c_data_##id, &nct_i3c_config_##id,    \
-			      POST_KERNEL, CONFIG_I3C_CONTROLLER_INIT_PRIORITY,                       \
-			      &nct_i3c_driver_api);
+	DEVICE_DT_INST_DEFINE(inst, nct_i3c_init, NULL, &nct_i3c_data_##inst,                    \
+			      &nct_i3c_config_##inst, POST_KERNEL,                        \
+			      CONFIG_I3C_CONTROLLER_INIT_PRIORITY, &nct_i3c_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I3C_NCT_DEVICE)
+
+/*************************************************************************************************/
+// For v2.6 mctp
+
+int i3c_nct_master_request_ibi(struct i3c_device_desc *i3cdev, struct i3c_ibi_callbacks *cb)
+{
+	// For 2.6
+	struct i3c_nct_ibi_priv *ibi_priv;
+
+	if (i3cdev->controller_priv != NULL) {
+		LOG_ERR("IBI already registered for device %s", i3cdev->dev->name);
+		return -EALREADY;
+	}
+
+	ibi_priv = (struct i3c_nct_ibi_priv *)malloc(sizeof(struct i3c_nct_ibi_priv) * 1);
+	ibi_priv->ibi.enable = false;
+	ibi_priv->ibi.callbacks = cb;
+	ibi_priv->ibi.context = i3cdev;
+	ibi_priv->ibi.incomplete = NULL;
+
+	i3cdev->controller_priv = ibi_priv;
+	return 0;
+}
+
+int i3c_nct_slave_register(const struct device *dev, struct i3c_slave_setup *slave_data)
+{
+	struct nct_i3c_data *data = dev->data;
+
+	__ASSERT(slave_data->max_payload_len <= CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE,
+		"msg_size should less than %d.\n", CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE);
+
+	data->slave_data.max_payload_len = slave_data->max_payload_len;
+	data->slave_data.callbacks = slave_data->callbacks;
+	data->slave_data.dev = slave_data->dev;
+
+	return 0;
+}
+
+
+int i3c_nct_slave_put_read_data(const struct device *dev, struct i3c_slave_payload *payload,
+				   struct i3c_ibi_payload *ibi_notify)
+{
+//	const struct nct_i3c_config *config = dev->config;
+	struct nct_i3c_data *data = dev->data;
+	uint32_t event_en;
+	int ret;
+//	uint8_t *xfer_buf;
+	struct i3c_reg *i3c_inst = HAL_INSTANCE(dev);
+	struct i3c_ibi request;
+	uint8_t bcr;
+
+	__ASSERT_NO_MSG(payload);
+	__ASSERT_NO_MSG(payload->buf);
+	__ASSERT_NO_MSG(payload->size);
+
+	k_mutex_lock(&data->lock_mutex, K_FOREVER);
+
+//	if (config->priv_xfer_pec) {
+//		uint8_t pec_v;
+//		uint8_t addr_rnw;
+//	 
+//	 	addr_rnw = (uint8_t)I3C_GET_REG_DYNADDR(port) >> 1;
+//	 	pec_v = crc8_ccitt(0, &addr_rnw, 1);
+//	 
+//	 	xfer_buf = (uint8_t *)&data->buf[1];
+//	 	pec_v = crc8_ccitt(pec_v, xfer_buf, data->size - 1);
+//	 	LOG_DBG("pec = %x", pec_v);
+//	 	xfer_buf = (uint8_t *)&data->buf[0];
+//	 	xfer_buf[data->size] = pec_v;
+//	 	nct_i3c_target_tx_write(dev, data->buf, data->size + 1);
+//	} else {
+		nct_i3c_target_tx_write(dev, payload->buf, payload->size, 0);
+//	}
+
+	target_register_tx_fifo_empty_cb(tx_fifo_empty_handler);
+
+	if (ibi_notify) {
+		ret = i3c_slave_get_event_enabling(dev, &event_en);
+		if (ret || !(event_en & I3C_SLAVE_EVENT_SIR)) {
+			/* master should polling pending interrupt by GetSTATUS */
+			SET_FIELD(i3c_inst->CTRL, NCT_I3C_CTRL_PENDINT, 0x01);
+			k_mutex_unlock(&data->lock_mutex);
+			return 0;
+		}
+
+		bcr = data->config_target.bcr;
+		if (!(bcr & I3C_BCR_IBI_REQUEST_CAPABLE)) {
+			LOG_ERR("Device is not IBI request capable");
+			k_mutex_unlock(&data->lock_mutex);
+			return -EINVAL;
+		}
+
+		if (bcr & I3C_BCR_IBI_PAYLOAD_HAS_DATA_BYTE)
+		{
+			if (ibi_notify->payload_len == 0) {
+				LOG_ERR("IBI payload length is zero, but BCR indicates it should have data byte");
+				k_mutex_unlock(&data->lock_mutex);
+				return -EINVAL;
+			}
+
+//			if (config->ibi_append_pec) {
+//				pec = calculate_pec(ibi_notify->payload, ibi_notify->payload_len);
+//				ibi_notify->payload[ibi_notify->payload_len] = pec;
+//				ibi_notify->payload_len++;
+//			} 
+		}
+		else if (ibi_notify->payload_len > 0) {
+			LOG_ERR("IBI payload length is not zero, but BCR indicates it should not have data byte");
+			k_mutex_unlock(&data->lock_mutex);
+			return -EINVAL;
+		}
+
+		request.ibi_type = I3C_IBI_TARGET_INTR;
+		request.payload = ibi_notify->payload;
+		request.payload_len = ibi_notify->payload_len;
+		nct_i3c_target_ibi_raise(dev, &request);
+	}
+
+	/*
+	 * osEventFlagsClear(obj->data_event, ~osFlagsError);
+	 * if (config->priv_xfer_pec) {
+	 *   xfer_buf = pec_append(dev, data->buf, data->size);
+	 *   i3c_npcm4xx_wr_tx_fifo(obj, xfer_buf, data->size + 1);
+	 *   k_free(xfer_buf);
+	 * } else {
+	 *   i3c_npcm4xx_wr_tx_fifo(obj, data->buf, data->size);
+	 * }
+	 */
+
+	k_mutex_unlock(&data->lock_mutex);
+
+	return 0;
+}
+
+int i3c_nct_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
+{
+	struct i3c_reg *i3c_inst;
+
+	if (dev == NULL) {
+		LOG_ERR("Device is NULL");
+		return -EINVAL;
+	}
+
+	if (dynamic_addr == NULL) {
+		LOG_ERR("dynamic_addr is NULL");
+		return -EINVAL;
+	}
+
+	i3c_inst = HAL_INSTANCE(dev);
+	*dynamic_addr = GET_FIELD(i3c_inst->DYNADDR, NCT_I3C_DYNADDR_DADDR);
+	return 0;
+}
+
+int i3c_nct_slave_get_event_enabling(const struct device *dev, uint32_t *event_en)
+{
+	struct i3c_reg *i3c_inst;
+	uint32_t val;
+
+	if (dev == NULL) {
+		LOG_ERR("Device is NULL");
+		return -EINVAL;
+	}
+
+	if (event_en == NULL) {
+		LOG_ERR("event_en is NULL");
+		return -EINVAL;
+	}
+
+	i3c_inst = HAL_INSTANCE(dev);
+	val = 0;
+
+	if (!IS_BIT_SET(i3c_inst->STATUS, NCT_I3C_STATUS_IBIDIS)) {
+		val |= I3C_SLAVE_EVENT_SIR;
+	}
+
+	if (!IS_BIT_SET(i3c_inst->STATUS, NCT_I3C_STATUS_MRDIS)) {
+		val |= I3C_SLAVE_EVENT_MR;
+	}
+	
+	if (!IS_BIT_SET(i3c_inst->STATUS, NCT_I3C_STATUS_HJDIS)) {
+		val |= I3C_SLAVE_EVENT_HJ;
+	}
+
+	*event_en = val;
+	return 0;
+}
+/*************************************************************************************************/

--- a/drivers/i3c/i3c_nct.h
+++ b/drivers/i3c/i3c_nct.h
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_I3C_I3C_NCT_H_
+#define ZEPHYR_DRIVERS_I3C_I3C_NCT_H_
+
+#include <zephyr/toolchain.h>
+#include <zephyr/types.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/drivers/gpio.h>
+
+/* Support 8 - 4095 bytes */
+#define MAX_I3C_PAYLOAD_SIZE	(MAX_I3C_DATA_SIZE + 0)
+#define MAX_I3C_DATA_SIZE		256							// 252 + 1 pec, or 256 
+
+/* MIPI I3C MDB definition: see https://www.mipi.org/MIPI_I3C_mandatory_data_byte_values_public */
+#define IBI_MDB_ID(grp, id)		((((grp) << 5) & GENMASK(7, 5)) | ((id) & GENMASK(4, 0)))
+#define IBI_MDB_GET_GRP(m)		(((m) & GENMASK(7, 5)) >> 5)
+#define IBI_MDB_GET_ID(m)		((m) & GENMASK(4, 0))
+
+#define IBI_MDB_GRP_PENDING_READ_NOTIF	0x5
+#define IS_MDB_PENDING_READ_NOTIFY(m)	(IBI_MDB_GET_GRP(m) == IBI_MDB_GRP_PENDING_READ_NOTIF)
+#define IBI_MDB_MIPI_DBGDATAREADY		IBI_MDB_ID(IBI_MDB_GRP_PENDING_READ_NOTIF, 0xd)
+#define IBI_MDB_MCTP					IBI_MDB_ID(IBI_MDB_GRP_PENDING_READ_NOTIF, 0xe)
+/* Interrupt ID 0x10 to 0x1F are for vendor specific */
+
+/**
+ * @brief IBI callback function structure
+ * @param write_requested callback function to return a memory block for receiving IBI data
+ * @param write_done callback function to process the received IBI data
+ */
+struct i3c_ibi_callbacks {
+	struct i3c_ibi_payload* (*write_requested)(struct i3c_device_desc *i3cdev);
+	void (*write_done)(struct i3c_device_desc *i3cdev);
+};
+
+/* slave driver structure */
+struct i3c_slave_payload {
+	int size;
+	void *buf;
+};
+
+/**
+ * @brief slave callback function structure
+ * @param write_requested callback function to return a memory block for receiving data sent from
+ *                        the master device
+ * @param write_done callback function to process the received IBI data
+ */
+struct i3c_slave_callbacks {
+	struct i3c_slave_payload* (*write_requested)(const struct device *dev);
+	void (*write_done)(const struct device *dev);
+};
+
+struct i3c_slave_setup {
+	int max_payload_len;
+	const struct device *dev;
+	const struct i3c_slave_callbacks *callbacks;
+};
+
+struct i3c_nct_ibi_priv {
+	int pos;
+	struct {
+		int enable;
+		struct i3c_ibi_callbacks *callbacks;
+		struct i3c_device_desc *context;
+		struct i3c_ibi_payload *incomplete;
+	} ibi;
+};
+
+/* slave events */
+#define I3C_SLAVE_EVENT_SIR		BIT(0)
+#define I3C_SLAVE_EVENT_MR		BIT(1)
+#define I3C_SLAVE_EVENT_HJ		BIT(2)
+
+// i3c APIs defined by ASPEED in v2.6, but changed to i3c.h by intel from v3.2
+//#define i3c_master_attach_device		i3c_nct_master_attach_device
+//#define i3c_master_detach_device		i3c_nct_master_detach_device
+//#define i3c_master_send_ccc				i3c_nct_master_send_ccc
+//#define i3c_master_priv_xfer			i3c_nct_master_priv_xfer
+#define i3c_master_request_ibi			i3c_nct_master_request_ibi
+//#define i3c_master_enable_ibi			i3c_nct_master_enable_ibi
+//#define i3c_master_send_entdaa			i3c_nct_master_send_entdaa
+#define i3c_slave_register				i3c_nct_slave_register
+//#define i3c_slave_send_sir				i3c_npcm4xx_slave_send_sir
+#define i3c_slave_put_read_data			i3c_nct_slave_put_read_data
+#define i3c_slave_get_dynamic_addr		i3c_nct_slave_get_dynamic_addr
+#define i3c_slave_get_event_enabling	i3c_nct_slave_get_event_enabling
+
+int i3c_nct_master_request_ibi(struct i3c_device_desc *i3cdev, struct i3c_ibi_callbacks *cb);
+int i3c_nct_slave_register(const struct device *dev, struct i3c_slave_setup *slave_data);
+int i3c_nct_slave_put_read_data(const struct device *dev, struct i3c_slave_payload *data,
+				   struct i3c_ibi_payload *ibi_notify);
+int i3c_nct_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr);
+int i3c_nct_slave_get_event_enabling(const struct device *dev, uint32_t *event_en);
+/*************************************************************************************************/
+
+/* Operation type */
+enum nct_i3c_oper_state {
+	I3C_OP_STATE_IDLE,
+	I3C_OP_STATE_WR,
+	I3C_OP_STATE_RD,
+	I3C_OP_STATE_IBI,
+	I3C_OP_STATE_CCC,
+	I3C_OP_STATE_MAX,
+};
+
+/* I3C timing configuration for each i3c/i2c speed */
+struct nct_i3c_timing_cfg {
+	uint8_t ppbaud;   /* Push-Pull high period */
+	uint8_t pplow;    /* Push-Pull low period */
+	uint8_t odhpp;    /* Open-Drain high period */
+	uint8_t odbaud;   /* Open-Drain low period */
+	uint8_t i2c_baud; /* I2C period */
+};
+
+/* NCT I3C Configuration */
+struct nct_i3c_config {
+	/* Common I3C Driver Config */
+	struct i3c_driver_config common;
+
+	/* Pointer to controller registers. */
+	struct i3c_reg *base;
+
+	/* Clock control subsys related struct. */
+	uint32_t clk_cfg;
+
+	/* Pointer to pin control device. */
+	const struct pinctrl_dev_config *pincfg;
+
+	/* Interrupt configuration function. */
+	void (*irq_config_func)(const struct device *dev);
+
+	struct {
+		uint32_t i3c_pp_scl_hz; /* I3C push pull clock frequency in Hz. */
+		uint32_t i3c_od_scl_hz; /* I3C open drain clock frequency in Hz. */
+		uint32_t i2c_scl_hz;    /* I2C clock frequency in Hz */
+	} clocks;
+
+	/* support pec */
+	bool priv_xfer_pec;
+	bool ibi_append_pec;
+
+#ifdef CONFIG_I3C_NCT_DMA
+	struct pdma_dsct_reg *pdma_rx;
+	struct pdma_dsct_reg *pdma_tx;
+#endif
+};
+
+/* NCT I3C Data */
+struct nct_i3c_data {
+	struct i3c_driver_data common; /* Common i3c driver data */
+	struct k_mutex lock_mutex;     /* Mutex of i3c controller */
+	struct k_sem sync_sem;         /* Semaphore used for synchronization */
+	struct k_sem ibi_lock_sem;     /* Semaphore used for ibi */
+
+	/* Target data */
+	struct i3c_target_config *target_config;
+	/* Configuration parameters for I3C hardware to act as target device */
+	struct i3c_config_target config_target;
+	struct k_sem target_lock_sem;       /* Semaphore used for i3c target */
+	struct k_sem target_event_lock_sem; /* Semaphore used for i3c target ibi_raise() */
+
+	enum nct_i3c_oper_state oper_state; /* Operation state */
+
+#ifdef CONFIG_I3C_NCT_DMA
+	uint8_t dma_rx_buf[MAX_I3C_PAYLOAD_SIZE];
+	uint16_t dma_rx_len;
+	uint16_t dma_triggered; /* The bit n is set to 1 if the n-th DMA channel is triggered */
+	bool tx_valid;          /* Tx has valid data */
+
+	uint8_t pdma_rx_buf[2][MAX_I3C_PAYLOAD_SIZE];
+	struct i3c_slave_payload slave_rx_payload[2];
+	struct i3c_slave_payload *rx_payload_curr;
+	int rx_payload_in;
+	int rx_payload_out;
+
+#else
+	uint8_t rx_buf[MAX_I3C_PAYLOAD_SIZE];
+	uint16_t rx_len;
+	uint8_t *tx_buf;
+	uint16_t tx_len;
+#endif
+
+#ifdef CONFIG_I3C_USE_IBI
+	struct {
+		/* List of addresses used in the MIBIRULES register. */
+		uint8_t addr[5];
+
+		/* Number of valid addresses in MIBIRULES. */
+		uint8_t num_addr;
+
+		/* True if all addresses have MSB set. */
+		bool msb;
+
+		/* True if all target devices require mandatory byte for IBI. */
+		bool has_mandatory_byte;
+	} ibi;
+#endif
+
+#ifdef CONFIG_I3C_NCT_DMA
+	struct pdma_dsct_reg dsct_sg[4] __aligned(4); /* use for dma, 4-bytes align */
+#endif
+
+	// for v2.6
+	struct i3c_slave_setup slave_data;
+	struct i3c_slave_payload *rx_payload;	
+};
+
+
+
+#endif /* ZEPHYR_DRIVERS_I3C_I3C_NCT_H_ */

--- a/drivers/i3c/i3c_nct_ext_device.c
+++ b/drivers/i3c/i3c_nct_ext_device.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nuvoton_nct_i3c_ext_device
+
+#include "i3c_nct.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(nct_i3c_ext_target, CONFIG_I3C_LOG_LEVEL);
+
+/* APIs */
+typedef int (*nct_i3c_i2c_read_ptr)(void *handle, uint8_t reg_addr, uint8_t *value, uint8_t len);
+typedef int (*nct_i3c_i2c_write_ptr)(void *handle, uint8_t reg_addr, uint8_t *value, uint8_t len);
+typedef int (*nct_i3c_read_ptr)(void *handle, uint8_t reg_addr, uint8_t *value, uint8_t len);
+typedef int (*nct_i3c_write_ptr)(void *handle, uint8_t reg_addr, uint8_t *value, uint8_t len);
+
+int ext_dev_i3c_i2c_read(void *handle, uint8_t reg_addr, uint8_t *value, uint8_t len)
+{
+	return -ENOTSUP;
+}
+
+int ext_dev_i3c_i2c_write(void *handle, uint8_t reg_addr, uint8_t *value, uint8_t len)
+{
+	return -ENOTSUP;
+}
+
+int ext_dev_i3c_read(void *handle, uint8_t reg_addr, uint8_t *value, uint8_t len)
+{
+	struct i3c_device_desc *target = **(struct i3c_device_desc ***)handle;
+
+	return i3c_burst_read(target, reg_addr, value, len);
+}
+
+int ext_dev_i3c_write(void *handle, uint8_t reg_addr, uint8_t *value, uint8_t len)
+{
+	struct i3c_device_desc *target = **(struct i3c_device_desc ***)handle;
+
+	return i3c_burst_write(target, reg_addr, value, len);
+}
+
+typedef struct {
+	nct_i3c_i2c_read_ptr	i3c_i2c_read;
+	nct_i3c_i2c_write_ptr	i3c_i2c_write;
+	nct_i3c_read_ptr		i3c_read;
+	nct_i3c_write_ptr		i3c_write;
+
+	void *handle;
+} dev_ctx_t;
+
+struct nct_i3c_ext_dev_config {
+	dev_ctx_t ctx;
+	union {
+		const struct i2c_dt_spec i2c;
+		struct i3c_device_desc **i3c;
+	} dev_cfg;
+
+//#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+//	struct {
+		const struct device *bus;
+		const struct i3c_device_id dev_id;
+		const uint8_t static_addr;
+		const uint8_t dynamic_addr;
+//	} i3c;
+//#endif	
+};
+
+struct nct_i3c_ext_dev_data
+{
+	struct i3c_device_desc *i3c_dev;
+};
+
+static int i3c_target_init(const struct device *dev)
+{
+	const struct nct_i3c_ext_dev_config *const config = dev->config;
+	struct nct_i3c_ext_dev_data *data = dev->data;
+
+	if (config->bus != NULL) {
+		/*
+		 * Need to grab the pointer to the I3C device descriptor
+		 * before we can talk to the device.
+		 */
+		data->i3c_dev = i3c_device_find(config->bus, &config->dev_id);
+		if (data->i3c_dev == NULL) {
+			LOG_ERR("Cannot find I3C device descriptor");
+			return -ENODEV;
+		}
+	}
+
+    return 0;
+}
+
+/* APIs */
+int nct_i3c_i2c_ext_dev_api_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs, uint16_t addr)
+{
+	return -ENOTSUP;
+}
+
+int nct_i3c_ext_dev_configure(const struct device *dev, enum i3c_config_type type, void *config)
+{
+	if (type != I3C_CONFIG_TARGET) {
+		LOG_ERR("Should be target mode only");
+		return -EINVAL;
+	}
+
+	return i3c_target_init(dev);
+}
+
+int nct_i3c_ext_dev_config_get(const struct device *dev, enum i3c_config_type type, void *config)
+{
+	if ((dev == NULL) || (config == NULL)) {
+		return -EINVAL;
+	}
+
+	if (type != I3C_CONFIG_TARGET) {
+		return -ENOTSUP;
+	}
+
+	// struct nct_i3c_data *dev_data = dev->data;
+	// struct nct_i3c_config_target *cfg = config;
+
+	return -ENOTSUP;
+}
+
+int nct_i3c_ext_dev_xfers(const struct device *dev, struct i3c_device_desc *target, \
+	struct i3c_msg *msgs, uint8_t num_msgs)
+{
+	return -ENOTSUP;
+}
+
+int nct_i3c_ext_dev_ibi_raise(const struct device *dev, struct i3c_ibi *request)
+{
+	return -ENOTSUP;
+}
+
+int nct_i3c_ext_dev_target_register(const struct device *dev, struct i3c_target_config *cfg)
+{
+	return -ENOTSUP;
+}
+
+int nct_i3c_ext_dev_target_unregister(const struct device *dev, struct i3c_target_config *cfg)
+{
+	return -ENOTSUP;
+}
+
+int nct_i3c_ext_dev_target_tx_write(const struct device *dev, uint8_t *buf, uint16_t len, \
+	uint8_t hdr_mode)
+{
+	return -ENOTSUP;
+}
+
+static const struct i3c_driver_api i3c_target_driver_api = {
+	.i2c_api = {
+		.transfer = nct_i3c_i2c_ext_dev_api_transfer,	/* Transfer data to/from I2C device */
+	},
+	.configure = nct_i3c_ext_dev_configure,
+	.config_get = nct_i3c_ext_dev_config_get,
+	.i3c_xfers = nct_i3c_ext_dev_xfers,						/* Transfer messages in I3C mode */
+	.ibi_raise = nct_i3c_ext_dev_ibi_raise,					/* Raise IBI */
+	.target_register = nct_i3c_ext_dev_target_register,		/* Register target device */
+	.target_unregister = nct_i3c_ext_dev_target_unregister,	/* Unregister target device */
+	.target_tx_write = nct_i3c_ext_dev_target_tx_write,		/* Write data to controller */
+};
+
+/* External target device */
+#define NCT_I3C_EXTERNAL_DEVICE_INIT(inst)                               \
+	static struct nct_i3c_ext_dev_data i3c_target_data_##inst;							\
+    static const struct nct_i3c_ext_dev_config i3c_target_config_##inst = {				\
+		/* Add support APIs here */														\
+		.ctx.i3c_i2c_read = ext_dev_i3c_i2c_read,										\
+		.ctx.i3c_i2c_write = ext_dev_i3c_i2c_write,										\
+		.ctx.i3c_read = ext_dev_i3c_read,												\
+		.ctx.i3c_write = ext_dev_i3c_write,												\
+		\
+		/* reserve a space to restore device handle to be used in APIs */				\
+		.ctx.handle = (void *)&i3c_target_config_##inst.dev_cfg,						\
+		\
+		/* pointer to the target device node in i3c_target_init */						\
+		.dev_cfg.i3c = &i3c_target_data_##inst.i3c_dev,									\
+		\
+		/* data used to search the device node */										\
+		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),									\
+		.dev_id = I3C_DEVICE_ID_DT_INST(inst),										\
+		.static_addr = DT_PROP_BY_IDX(DT_DRV_INST(inst), reg, 0),									\
+		.dynamic_addr = DT_INST_PROP(inst, assigned_address),										\
+	};																					\
+	DEVICE_DT_INST_DEFINE(inst, i3c_target_init, NULL,									\
+		&i3c_target_data_##inst, &i3c_target_config_##inst,								\
+		POST_KERNEL, CONFIG_I3C_TARGET_INIT_PRIORITY, 				\
+		&i3c_target_driver_api);
+
+#define I3C_EXTERNAL_DEVICE_INIT(inst, init_priority)				\
+	COND_CODE_0(DT_INST_PROP_BY_IDX(inst, reg, 1),	\
+		(/* NCT_I2C_EXTERNAL_DEVICE_INIT(inst) */),	\
+		(NCT_I3C_EXTERNAL_DEVICE_INIT(inst, init_priority)));
+
+DT_INST_FOREACH_STATUS_OKAY(NCT_I3C_EXTERNAL_DEVICE_INIT)

--- a/drivers/i3c/slave/CMakeLists.txt
+++ b/drivers/i3c/slave/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 ASPEED Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_sources_ifdef(CONFIG_I3C_SLAVE_MQUEUE	i3c_slave_mqueue.c)

--- a/drivers/i3c/slave/Kconfig
+++ b/drivers/i3c/slave/Kconfig
@@ -1,0 +1,24 @@
+# I3C Slave configuration options
+
+# Copyright (c) 2021 ASPEED Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# I3C slave options
+#
+menuconfig I3C_SLAVE
+	bool "I3C Slave Drivers"
+	help
+	  Enable I3C Slave Driver Configuration
+
+if I3C_SLAVE
+
+config I3C_SLAVE_INIT_PRIORITY
+	int "Init priority"
+	default 60
+	help
+	  I3C Slave device driver initialization priority.
+
+	source "drivers/i3c/slave/Kconfig.i3c_slave_mqueue"
+
+endif # I3C_SLAVE

--- a/drivers/i3c/slave/Kconfig.i3c_slave_mqueue
+++ b/drivers/i3c/slave/Kconfig.i3c_slave_mqueue
@@ -1,0 +1,10 @@
+# I3C Slave mqueue configuration options
+
+# Copyright (c) 2021 Aspeed Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config I3C_SLAVE_MQUEUE
+	bool "I3C Slave MQueue driver"
+	default y
+	help
+	  Enable I3C slave mqueue driver

--- a/drivers/i3c/slave/i3c_slave_mqueue.c
+++ b/drivers/i3c/slave/i3c_slave_mqueue.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2023 Zephyr Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT i3c_slave_mqueue
+
+#include <soc.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/sys/sys_io.h>
+
+#include <stdlib.h>
+#include "i3c/i3c_nct.h"
+
+#define LOG_LEVEL CONFIG_I3C_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(i3c_slave_mqueue);
+
+struct i3c_slave_mqueue_config {
+	char *controller_name;
+	int msg_size;
+	int num_of_msgs;
+	int mdb;
+};
+
+struct i3c_slave_mqueue_obj {
+	const struct device *i3c_controller;
+	struct i3c_slave_payload *msg_curr;
+	struct i3c_slave_payload *msg_queue;
+	int in;
+	int out;
+};
+
+#define DEV_CFG(dev)			((struct i3c_slave_mqueue_config *)(dev)->config)
+#define DEV_DATA(dev)			((struct i3c_slave_mqueue_obj *)(dev)->data)
+
+static struct i3c_slave_payload *i3c_slave_mqueue_write_requested(const struct device *dev)
+{
+	struct i3c_slave_mqueue_obj *obj = DEV_DATA(dev);
+
+	return obj->msg_curr;
+}
+
+static void i3c_slave_mqueue_write_done(const struct device *dev)
+{
+	struct i3c_slave_mqueue_obj *obj = DEV_DATA(dev);
+	struct i3c_slave_mqueue_config *config = DEV_CFG(dev);
+
+#ifdef DBG_DUMP
+	int i;
+	uint8_t *buf = (uint8_t *)obj->msg_curr->buf;
+
+	printk("%s: %d %d\n", __func__, obj->in, obj->out);
+	for (i = 0; i < obj->msg_curr->size; i++) {
+		printk("%02x\n", buf[i]);
+	}
+#endif
+	/* update pointer */
+	obj->in = (obj->in + 1) & (config->num_of_msgs - 1);
+	obj->msg_curr = &obj->msg_queue[obj->in];
+
+	/* if queue full, skip the oldest un-read message */
+	if (obj->in == obj->out) {
+		LOG_WRN("buffer overflow\n");
+		obj->out = (obj->out + 1) & (config->num_of_msgs - 1);
+	}
+}
+
+static const struct i3c_slave_callbacks i3c_slave_mqueue_callbacks = {
+	.write_requested = i3c_slave_mqueue_write_requested,
+	.write_done = i3c_slave_mqueue_write_done,
+};
+
+/**
+ * @brief application reads the data from the message queue
+ *
+ * @param dev i3c slave mqueue device
+ * @return int -1: message queue empty
+ */
+int i3c_slave_mqueue_read(const struct device *dev, uint8_t *dest, int budget)
+{
+	struct i3c_slave_mqueue_config *config = DEV_CFG(dev);
+	struct i3c_slave_mqueue_obj *obj = DEV_DATA(dev);
+	struct i3c_slave_payload *msg;
+	int ret;
+
+	if (obj->out == obj->in) {
+		return 0;
+	}
+
+	msg = &obj->msg_queue[obj->out];
+	ret = (msg->size > budget) ? budget : msg->size;
+	memcpy(dest, msg->buf, ret);
+
+	obj->out = (obj->out + 1) & (config->num_of_msgs - 1);
+
+	return ret;
+}
+
+extern int target_wait_for_tx_fifo_empty(k_timeout_t timeout);
+
+int i3c_slave_mqueue_write(const struct device *dev, uint8_t *src, int size)
+{
+	struct i3c_slave_mqueue_config *config = DEV_CFG(dev);
+	struct i3c_slave_mqueue_obj *obj = DEV_DATA(dev);
+	struct i3c_ibi_payload ibi;
+	uint32_t event_en;
+	int ret;
+	uint8_t dynamic_addr;
+
+	// the i3c_controller is the target device node we try to manupulate
+	ret = i3c_slave_get_dynamic_addr(obj->i3c_controller, &dynamic_addr);
+	if (ret) {
+		return -ENOTCONN;
+	}
+
+	ret = i3c_slave_get_event_enabling(obj->i3c_controller, &event_en);
+	if (ret || !(event_en & I3C_SLAVE_EVENT_SIR)) {
+		return -EACCES;
+	}
+
+	struct i3c_slave_payload read_data;
+
+	read_data.buf = src;
+	read_data.size = size;
+
+	if (IS_MDB_PENDING_READ_NOTIFY(config->mdb)) {
+		/* response with ibi */
+#if 0
+		uint32_t ibi_data = config->mdb;
+
+		ibi.buf = (uint8_t *)&ibi_data;
+		ibi.size = 1;
+#else
+		ibi.payload[0] = (uint8_t)config->mdb;
+		ibi.payload_len = 1;
+#endif
+
+		ret = i3c_slave_put_read_data(obj->i3c_controller, &read_data, &ibi);
+		if (ret == 0) {
+			target_wait_for_tx_fifo_empty(K_FOREVER);
+		}
+
+		return ret;
+	}
+
+	/* response without ibi, master should support retry */
+	ret = i3c_slave_put_read_data(obj->i3c_controller, &read_data, NULL);
+	if (ret == 0) {
+		target_wait_for_tx_fifo_empty(K_FOREVER);
+	}
+
+	return ret;
+}
+
+static void i3c_slave_mqueue_init(const struct device *dev)
+{
+	struct i3c_slave_mqueue_config *config = DEV_CFG(dev);
+	struct i3c_slave_mqueue_obj *obj = DEV_DATA(dev);
+	struct i3c_slave_setup slave_data;
+	uint8_t *buf;
+	int i;
+
+	LOG_DBG("msg size %d, n %d\n", config->msg_size, config->num_of_msgs);
+	// LOG_DBG("bus name : %s\n", config->controller_name);
+	LOG_DBG("bus name : %s\n", obj->i3c_controller->name);
+	__ASSERT((config->num_of_msgs & (config->num_of_msgs - 1)) == 0,
+		 "number of msgs must be power of 2\n");
+
+	// obj->i3c_controller = device_get_binding(config->controller_name);
+
+	buf = (uint8_t *)malloc(config->msg_size * config->num_of_msgs);
+	if (!buf) {
+		LOG_ERR("failed to create message buffer\n");
+		return;
+	}
+
+	obj->msg_queue = (struct i3c_slave_payload *)malloc(sizeof(struct i3c_slave_payload) *
+							      config->num_of_msgs);
+	if (!obj->msg_queue) {
+		LOG_ERR("failed to create message queue\n");
+		return;
+	}
+
+	for (i = 0; i < config->num_of_msgs; i++) {
+		obj->msg_queue[i].buf = buf + (i * config->msg_size);
+		obj->msg_queue[i].size = 0;
+	}
+
+	obj->in = 0;
+	obj->out = 0;
+	obj->msg_curr = &obj->msg_queue[0];
+
+	slave_data.max_payload_len = config->msg_size;
+	slave_data.callbacks = &i3c_slave_mqueue_callbacks;
+	slave_data.dev = dev;
+	i3c_slave_register(obj->i3c_controller, &slave_data);
+}
+
+BUILD_ASSERT(CONFIG_I3C_SLAVE_INIT_PRIORITY > CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+	     "I3C controller must be initialized prior to target device initialization");
+
+#define I3C_SLAVE_MQUEUE_INIT(n)                               \
+	static int i3c_slave_mqueue_config_func_##n(const struct device *dev);                     \
+	static const struct i3c_slave_mqueue_config i3c_slave_mqueue_config_##n = {                \
+		/*.controller_name = DT_INST_BUS_LABEL(n),*/                                           \
+		.msg_size = DT_INST_PROP(n, msg_size),                                             \
+		.num_of_msgs = DT_INST_PROP(n, num_of_msgs),                                       \
+		.mdb = DT_INST_PROP(n, mandatory_data_byte),                                       \
+	};                                                                                         \
+												   \
+	static struct i3c_slave_mqueue_obj i3c_slave_mqueue_obj##n = {							\
+		.i3c_controller = DEVICE_DT_GET(DT_INST_BUS(n)),								  					\
+	};                                														\
+												   \
+	DEVICE_DT_INST_DEFINE(n, &i3c_slave_mqueue_config_func_##n, NULL,                          \
+			      &i3c_slave_mqueue_obj##n, &i3c_slave_mqueue_config_##n, POST_KERNEL, \
+			      CONFIG_I3C_SLAVE_INIT_PRIORITY, NULL);                     \
+												   \
+	static int i3c_slave_mqueue_config_func_##n(const struct device *dev)                      \
+	{                                                                                          \
+		i3c_slave_mqueue_init(dev);                                                        \
+		return 0;                                                                          \
+	}
+
+DT_INST_FOREACH_STATUS_OKAY(I3C_SLAVE_MQUEUE_INIT)

--- a/dts/arm/nuvoton/nct/nct66.dtsi
+++ b/dts/arm/nuvoton/nct/nct66.dtsi
@@ -374,6 +374,8 @@
 			status = "disabled";
 			#address-cells = <3>;
 			#size-cells = <0>;
+
+			bcr = <0x66>;	// Bit[7:6] = 01b, used to define controller roles
 		};
 
 		i3c6: i3c@40004a00 {
@@ -387,6 +389,8 @@
 			status = "disabled";
 			#address-cells = <3>;
 			#size-cells = <0>;
+
+			bcr = <0x66>;	// Bit[7:6] = 01b, used to define controller roles
 		};
 		
 		emac: ethernet@40018000 {

--- a/dts/arm/nuvoton/nct6694b.dtsi
+++ b/dts/arm/nuvoton/nct6694b.dtsi
@@ -14,7 +14,7 @@
 		reg = <0x00080000 DT_SIZE_M(2)>;
 	};
 
-	sram0: memory@10008000 {
+	sram0: memory@10068000 {
 		compatible = "mmio-sram";
 		reg = <0x10068000 DT_SIZE_K(384)>;
 	};

--- a/dts/bindings/i3c/i3c-device.yaml
+++ b/dts/bindings/i3c/i3c-device.yaml
@@ -61,3 +61,9 @@ properties:
     type: int
     description: |
       Dynamic address to be assigned to the device.
+
+  supports-setaasa:
+    type: boolean
+    description: |
+      Indicates if the device supports the CCC SETAASA. If true, it will
+      be used as an optimization for bus initialization.

--- a/dts/bindings/i3c/i3c-slave-mqueue.yaml
+++ b/dts/bindings/i3c/i3c-slave-mqueue.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: NUVOTON I3C MQueue device
+
+compatible: "i3c-slave-mqueue"
+
+include: base.yaml
+
+on-bus: i3c
+
+properties:
+    msg-size:
+      type: int
+      required: true
+      description: |
+        the size of the single message in byte, used to specify max read/write length
+
+    num-of-msgs:
+      type: int
+      required: true
+      description: |
+        number of the messages
+
+    mandatory-data-byte:
+      type: int
+      required: true
+      description: |
+        mandatory data byte (MDB), used to specify how slave provide response data

--- a/dts/bindings/i3c/nuvoton,nct-i3c-ext-device.yaml
+++ b/dts/bindings/i3c/nuvoton,nct-i3c-ext-device.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2018, 
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton external i3c device to test i3c controller
+
+compatible: "nuvoton,nct-i3c-ext-device"
+
+include: [sensor-device.yaml, i3c-device.yaml]

--- a/dts/bindings/i3c/nuvoton,nct-i3c.yaml
+++ b/dts/bindings/i3c/nuvoton,nct-i3c.yaml
@@ -35,8 +35,69 @@ properties:
   interrupts:
     required: true
 
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
   i3c-od-scl-hz:
     type: int
     description: |
       Open Drain Frequency for the I3C controller. When undefined, use
       the controller default or as specified by the I3C specification.
+
+  secondary:
+    type: boolean
+    description: Initialized as a secondary controller.
+
+  static-address:
+    type: int
+    description: |
+      Target static address.
+
+  tgt-pid:
+    type: array
+    description: |
+      Target 48-bit Provisioned ID.
+      array[0]: PID[47:33] MIPI manufacturer ID.
+                PID[32] ID type selector (i'b1 ramdom value, 1'b0 vendor fixed).
+      array[1]: PID[31:0] Random value or vendor fixed value.
+
+  bcr:
+    required: true
+    type: int
+    description: |
+      Bus Characteristics Register, used for bus enumeration with ENTDAA and
+      determine device role and capabilities of the device on the bus.
+
+  dcr:
+    type: int
+    description: |
+      Device Characteristics Register, used for bus enumeration with ENTDAA.
+
+  maximum-write:
+    type: int
+    default: 256
+    description: |
+      Maximum number of bytes that I3C controller may write to I3C target per message.
+      Range: 8 to 4095.
+
+  maximum-read:
+    type: int
+    default: 256
+    description: |
+      Maximum number of bytes that I3C controller may read from to I3C target per message.
+      Range: 8 to 4095.
+
+  ibi-append-pec:
+    type: boolean
+    description: |
+      Append PEC byte to the IBI data.
+
+  priv-xfer-pec:
+    type: boolean
+    description: |
+      Enable this option in slave mode if the i3c want to communicate with data that have PEC.
+      The PEC will auto append to the tail of the data when doing private transfer and verify
+      the PEC when receiving the data from master.

--- a/include/zephyr/drivers/i3c/addresses.h
+++ b/include/zephyr/drivers/i3c/addresses.h
@@ -14,8 +14,9 @@
  * @{
  */
 
-#include <zephyr/types.h>
-#include <zephyr/sys/sys_io.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
 #include <zephyr/sys/util.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -15,7 +15,8 @@
  * @{
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+
 #include <zephyr/device.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/util.h>
@@ -258,6 +259,14 @@ struct i3c_ccc_target_payload {
 	 * write to this after the transfer.
 	 */
 	size_t num_xfer;
+
+	/**
+	 * SDR Error Type
+	 *
+	 * Error from I3C Specification v1.1.1 section 5.1.10.2. It is expected
+	 * for the driver to write to this.
+	 */
+	enum i3c_sdr_controller_error_types err;
 };
 
 /**
@@ -288,6 +297,14 @@ struct i3c_ccc_payload {
 		 * It is expected for the driver to write to this after the transfer.
 		 */
 		size_t num_xfer;
+
+		/**
+		 * SDR Error Type
+		 *
+		 * Error from I3C Specification v1.1.1 section 5.1.10.2. It is expected
+		 * for the driver to write to this.
+		 */
+		enum i3c_sdr_controller_error_types err;
 	} ccc;
 
 	struct {
@@ -450,12 +467,28 @@ struct i3c_ccc_deftgts_target {
  * this CCC.
  */
 struct i3c_ccc_deftgts {
+	/** Number of Targets (and Groups) present on the I3C Bus */
+	uint8_t count;
+
 	/** Data describing the active controller */
 	struct i3c_ccc_deftgts_active_controller active_controller;
 
 	/** Data describing the target(s) on the bus */
 	struct i3c_ccc_deftgts_target targets[];
 } __packed;
+
+/**
+ * @brief Defining byte values for ENTTM.
+ */
+enum i3c_ccc_enttm_defbyte {
+	/** Remove all I3C Devices from Test Mode */
+	ENTTM_EXIT_TEST_MODE = 0x00U,
+
+	/** Indicates that I3C Devices shall return a random 32-bit value
+	 * in the PID during the Dynamic Address Assignment procedure
+	 */
+	ENTTM_VENDOR_TEST_MODE = 0x01U,
+};
 
 /**
  * @brief Payload for a single device address.
@@ -479,7 +512,7 @@ struct i3c_ccc_address {
 	 * - For GETACCCR, the correct address of Secondary
 	 *   Controller.
 	 *
-	 * @note For SETDATA, SETNEWDA and SETGRAP,
+	 * @note For SETDATA, SETNEWDA and SETGRPA,
 	 * the address is left-shift by 1, and bit[0] is always 0.
 	 *
 	 * @note Fpr SET GETACCCR, the address is left-shift by 1,
@@ -592,12 +625,8 @@ union i3c_ccc_getstatus {
 /** GETSTATUS Format 1 - Protocol Error bit. */
 #define I3C_CCC_GETSTATUS_PROTOCOL_ERR				BIT(5)
 
-/** GETSTATUS Format 1 - Activity Mode bit shift value. */
-#define I3C_CCC_GETSTATUS_ACTIVITY_MODE_SHIFT			6
-
 /** GETSTATUS Format 1 - Activity Mode bitmask. */
-#define I3C_CCC_GETSTATUS_ACTIVITY_MODE_MASK			\
-	(0x03U << I3C_CCC_GETSTATUS_ACTIVITY_MODE_SHIFT)
+#define I3C_CCC_GETSTATUS_ACTIVITY_MODE_MASK			GENMASK(7U, 6U)
 
 /**
  * @brief GETSTATUS Format 1 - Activity Mode
@@ -608,15 +637,10 @@ union i3c_ccc_getstatus {
  * @param status GETSTATUS Format 1 value
  */
 #define I3C_CCC_GETSTATUS_ACTIVITY_MODE(status)			\
-	(((status) & I3C_CCC_GETSTATUS_ACTIVITY_MODE_MASK)	\
-	 >> I3C_CCC_GETSTATUS_ACTIVITY_MODE_SHIFT)
-
-/** GETSTATUS Format 1 - Number of Pending Interrupts bit shift value. */
-#define I3C_CCC_GETSTATUS_NUM_INT_SHIFT				0
+	FIELD_GET(I3C_CCC_GETSTATUS_ACTIVITY_MODE_MASK, (status))
 
 /** GETSTATUS Format 1 - Number of Pending Interrupts bitmask. */
-#define I3C_CCC_GETSTATUS_NUM_INT_MASK				\
-	(0x0FU << I3C_CCC_GETSTATUS_NUM_INT_SHIFT)
+#define I3C_CCC_GETSTATUS_NUM_INT_MASK				GENMASK(3U, 0U)
 
 /**
  * @brief GETSTATUS Format 1 - Number of Pending Interrupts
@@ -627,8 +651,7 @@ union i3c_ccc_getstatus {
  * @param status GETSTATUS Format 1 value
  */
 #define I3C_CCC_GETSTATUS_NUM_INT(status)			\
-	(((status) & I3C_CCC_GETSTATUS_NUM_INT_MASK)		\
-	 >> I3C_CCC_GETSTATUS_NUM_INT_SHIFT)
+	FIELD_GET(I3C_CCC_GETSTATUS_NUM_INT_MASK, (status))
 
 /** GETSTATUS Format 2 - PERCR - Deep Sleep Detected bit. */
 #define I3C_CCC_GETSTATUS_PRECR_DEEP_SLEEP_DETECTED		BIT(0)
@@ -675,9 +698,39 @@ struct i3c_ccc_setbrgtgt {
 } __packed;
 
 /**
+ * @brief Indicate which format of getmxds to use.
+ */
+enum i3c_ccc_getmxds_fmt {
+	/** GETMXDS Format 1 */
+	GETMXDS_FORMAT_1,
+
+	/** GETMXDS Format 2 */
+	GETMXDS_FORMAT_2,
+
+	/** GETMXDS Format 3 */
+	GETMXDS_FORMAT_3,
+};
+
+/**
+ * @brief Enum for I3C Get Max Data Speed (GETMXDS) Format 3 Defining Byte Values.
+ */
+enum i3c_ccc_getmxds_defbyte {
+	/** Standard Target Write/Read speed parameters, and optional Maximum Read Turnaround Time
+	 */
+	GETMXDS_FORMAT_3_WRRDTURN = 0x00U,
+
+	/** Delay parameters for a Controller-capable Device, and it's expected Activity State
+	 * during a Controller Handoff
+	 */
+	GETMXDS_FORMAT_3_CRHDLY = 0x91U,
+
+	/** Invalid defining byte. */
+	GETMXDS_FORMAT_3_INVALID = 0x100,
+};
+
+
+/**
  * @brief Payload for GETMXDS CCC (Get Max Data Speed).
- *
- * @note This is only for GETMXDS Format 1 and Format 2.
  */
 union i3c_ccc_getmxds {
 	struct {
@@ -709,11 +762,11 @@ union i3c_ccc_getmxds {
 		 *
 		 * @see i3c_ccc_getmxds::fmt2
 		 */
-		uint8_t wrrdturn;
+		uint8_t wrrdturn[5];
 
 		/**
 		 * Defining Byte 0x91: CRHDLY
-		 * - Bit[2]: Set Bus Actibity State
+		 * - Bit[2]: Set Bus Activity State
 		 * - Bit[1:0]: Controller Handoff Activity State
 		 */
 		uint8_t crhdly1;
@@ -756,12 +809,8 @@ union i3c_ccc_getmxds {
 /** Get Max Data Speed (GETMXDS) - maxWr - Optional Defining Byte Support. */
 #define I3C_CCC_GETMXDS_MAXWR_DEFINING_BYTE_SUPPORT		BIT(3)
 
-/** Get Max Data Speed (GETMXDS) - Max Sustained Data Rate bit shift value. */
-#define I3C_CCC_GETMXDS_MAXWR_MAX_SDR_FSCL_SHIFT		0
-
 /** Get Max Data Speed (GETMXDS) - Max Sustained Data Rate bitmask. */
-#define I3C_CCC_GETMXDS_MAXWR_MAX_SDR_FSCL_MASK			\
-	(0x07U << I3C_CCC_GETMXDS_MAXWR_MAX_SDR_FSCL_SHIFT)
+#define I3C_CCC_GETMXDS_MAXWR_MAX_SDR_FSCL_MASK			GENMASK(2U, 0U)
 
 /**
  * @brief Get Max Data Speed (GETMXDS) - maxWr - Max Sustained Data Rate
@@ -772,19 +821,13 @@ union i3c_ccc_getmxds {
  * @param maxwr GETMXDS maxWr value.
  */
 #define I3C_CCC_GETMXDS_MAXWR_MAX_SDR_FSCL(maxwr)		\
-	(((maxwr) &						\
-	  I3C_CCC_GETMXDS_MAXWR_MAX_SDR_FSCL_MASK)		\
-	 >> I3C_CCC_GETMXDS_MAXWR_MAX_SDR_FSCL_SHIFT)
+	FIELD_GET(I3C_CCC_GETMXDS_MAXWR_MAX_SDR_FSCL_MASK, (maxwr))
 
 /** Get Max Data Speed (GETMXDS) - maxRd - Write-to-Read Permits Stop Between. */
 #define I3C_CCC_GETMXDS_MAXRD_W2R_PERMITS_STOP_BETWEEN		BIT(6)
 
-/** Get Max Data Speed (GETMXDS) - maxRd - Clock to Data Turnaround bit shift value. */
-#define I3C_CCC_GETMXDS_MAXRD_TSCO_SHIFT			3
-
 /** Get Max Data Speed (GETMXDS) - maxRd - Clock to Data Turnaround bitmask. */
-#define I3C_CCC_GETMXDS_MAXRD_TSCO_MASK				\
-	(0x07U << I3C_CCC_GETMXDS_MAXRD_TSCO_SHIFT)
+#define I3C_CCC_GETMXDS_MAXRD_TSCO_MASK				GENMASK(5U, 3U)
 
 /**
  * @brief Get Max Data Speed (GETMXDS) - maxRd - Clock to Data Turnaround
@@ -795,15 +838,10 @@ union i3c_ccc_getmxds {
  * @param maxrd GETMXDS maxRd value.
  */
 #define I3C_CCC_GETMXDS_MAXRD_TSCO(maxrd)			\
-	(((maxrd) & I3C_CCC_GETMXDS_MAXRD_TSCO_MASK)		\
-	 >> I3C_CCC_GETMXDS_MAXRD_TSCO_SHIFT)
-
-/** Get Max Data Speed (GETMXDS) - maxRd - Max Sustained Data Rate bit shift value. */
-#define I3C_CCC_GETMXDS_MAXRD_MAX_SDR_FSCL_SHIFT		0
+	FIELD_GET(I3C_CCC_GETMXDS_MAXRD_TSCO_MASK, (maxrd))
 
 /** Get Max Data Speed (GETMXDS) - maxRd - Max Sustained Data Rate bitmask. */
-#define I3C_CCC_GETMXDS_MAXRD_MAX_SDR_FSCL_MASK			\
-	(0x07U << I3C_CCC_GETMXDS_MAXRD_MAX_SDR_FSCL_SHIFT)
+#define I3C_CCC_GETMXDS_MAXRD_MAX_SDR_FSCL_MASK			GENMASK(2U, 0U)
 
 /**
  * @brief Get Max Data Speed (GETMXDS) - maxRd - Max Sustained Data Rate
@@ -814,19 +852,13 @@ union i3c_ccc_getmxds {
  * @param maxrd GETMXDS maxRd value.
  */
 #define I3C_CCC_GETMXDS_MAXRD_MAX_SDR_FSCL(maxrd)		\
-	(((maxrd) &						\
-	  I3C_CCC_GETMXDS_MAXRD_MAX_SDR_FSCL_MASK)		\
-	 >> I3C_CCC_GETMXDS_MAXRD_MAX_SDR_FSCL_SHIFT)
+	FIELD_GET(I3C_CCC_GETMXDS_MAXRD_MAX_SDR_FSCL_MASK, (maxrd))
 
 /** Get Max Data Speed (GETMXDS) - CRDHLY1 - Set Bus Activity State bit shift value. */
 #define I3C_CCC_GETMXDS_CRDHLY1_SET_BUS_ACT_STATE		BIT(2)
 
-/** Get Max Data Speed (GETMXDS) - CRDHLY1 - Controller Handoff Activity State bit shift value. */
-#define I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_SHIFT	0
-
 /** Get Max Data Speed (GETMXDS) - CRDHLY1 - Controller Handoff Activity State bitmask. */
-#define I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_MASK	\
-	(0x03U << I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_SHIFT)
+#define I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_MASK	GENMASK(1U, 0U)
 
 /**
  * @brief Get Max Data Speed (GETMXDS) - CRDHLY1 - Controller Handoff Activity State
@@ -837,9 +869,7 @@ union i3c_ccc_getmxds {
  * @param crhdly1 GETMXDS value.
  */
 #define I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE(crhdly1)	\
-	(((crhdly1) &						\
-	  I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_MASK)	\
-	 >> I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_SHIFT)
+	FIELD_GET(I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_MASK, (chrdly1))
 
 /**
  * @brief Indicate which format of GETCAPS to use.
@@ -919,7 +949,7 @@ union i3c_ccc_getcaps {
 		 * - Bit[7:0]: Reserved
 		 */
 		uint8_t getcaps[4];
-	} fmt1;
+	} fmt1 __aligned(4);
 
 	union {
 		/**
@@ -1018,16 +1048,9 @@ union i3c_ccc_getcaps {
 
 /**
  * @brief Get Optional Feature Capabilities Byte 2 (GETCAPS) Format 1 -
- *        Group Address Capabilities bit shift value.
- */
-#define I3C_CCC_GETCAPS2_GRPADDR_CAP_SHIFT			4
-
-/**
- * @brief Get Optional Feature Capabilities Byte 2 (GETCAPS) Format 1 -
  *        Group Address Capabilities bitmask.
  */
-#define I3C_CCC_GETCAPS2_GRPADDR_CAP_MASK			\
-	(0x03U << I3C_CCC_GETCAPS2_GRPADDR_CAP_SHIFT)
+#define I3C_CCC_GETCAPS2_GRPADDR_CAP_MASK			GENMASK(5U, 4U)
 
 /**
  * @brief Get Optional Feature Capabilities Byte 2 (GETCAPS) Format 1 - Group Address Capabilities.
@@ -1038,22 +1061,13 @@ union i3c_ccc_getcaps {
  * @param getcaps2 GETCAPS2 value.
  */
 #define I3C_CCC_GETCAPS2_GRPADDR_CAP(getcaps2)			\
-	(((getcaps2) &						\
-	  I3C_CCC_GETCAPS2_GRPADDR_CAP_MASK)			\
-	 >> I3C_CCC_GETCAPS_GRPADDR_CAP_SHIFT)
-
-/**
- * @brief Get Optional Feature Capabilities Byte 2 (GETCAPS) Format 1 -
- *        I3C 1.x Specification Version bit shift value.
- */
-#define I3C_CCC_GETCAPS2_SPEC_VER_SHIFT				0
+	FIELD_GET(I3C_CCC_GETCAPS2_GRPADDR_CAP_MASK, (getcaps2))
 
 /**
  * @brief Get Optional Feature Capabilities Byte 2 (GETCAPS) Format 1 -
  *        I3C 1.x Specification Version bitmask.
  */
-#define I3C_CCC_GETCAPS2_SPEC_VER_MASK				\
-	(0x0FU << I3C_CCC_GETCAPS2_SPEC_VER_SHIFT)
+#define I3C_CCC_GETCAPS2_SPEC_VER_MASK				GENMASK(3U, 0U)
 
 /**
  * @brief Get Optional Feature Capabilities Byte 2 (GETCAPS) Format 1 -
@@ -1065,9 +1079,7 @@ union i3c_ccc_getcaps {
  * @param getcaps2 GETCAPS2 value.
  */
 #define I3C_CCC_GETCAPS2_SPEC_VER(getcaps2)			\
-	(((getcaps2) &						\
-	  I3C_CCC_GETCAPS2_SPEC_VER_MASK)			\
-	 >> I3C_CCC_GETCAPS_SPEC_VER_SHIFT)
+	FIELD_GET(I3C_CCC_GETCAPS2_SPEC_VER_MASK, (getcaps2))
 
 /**
  * @brief Get Optional Feature Capabilities Byte 3 (GETCAPS) Format 1 -
@@ -1183,12 +1195,8 @@ union i3c_ccc_getcaps {
  */
 #define I3C_CCC_GETCAPS_CRCAPS2_DELAYED_CONTROLLER_HANDOFF	BIT(3)
 
-/** Get Capabilities (GETCAPS) - VTCAP1 - Virtual Target Type bit shift value. */
-#define I3C_CCC_GETCAPS_VTCAP1_VITRUAL_TARGET_TYPE_SHIFT	0
-
 /** Get Capabilities (GETCAPS) - VTCAP1 - Virtual Target Type bitmask. */
-#define I3C_CCC_GETCAPS_VTCAP1_VITRUAL_TARGET_TYPE_MASK		\
-	(0x07U << I3C_CCC_GETCAPS_VTCAP1_VITRUAL_TARGET_TYPE_SHIFT)
+#define I3C_CCC_GETCAPS_VTCAP1_VITRUAL_TARGET_TYPE_MASK		GENMASK(2U, 0U)
 
 /**
  * @brief Get Capabilities (GETCAPS) - VTCAP1 - Virtual Target Type
@@ -1199,9 +1207,7 @@ union i3c_ccc_getcaps {
  * @param vtcap1 VTCAP1 value.
  */
 #define I3C_CCC_GETCAPS_VTCAP1_VITRUAL_TARGET_TYPE(vtcap1)	\
-	(((vtcap1) &						\
-	  I3C_CCC_GETCAPS_VTCAP1_VITRUAL_TARGET_TYPE_MASK)	\
-	 >> I3C_CCC_GETCAPS_VTCAP1_VITRUAL_TARGET_TYPE_SHIFT)
+	FIELD_GET(I3C_CCC_GETCAPS_VTCAP1_VITRUAL_TARGET_TYPE_MASK, (vtcap1))
 
 /**
  * @brief Get Virtual Target Capabilities Byte 1 (GETCAPS) Format 2 -
@@ -1215,12 +1221,8 @@ union i3c_ccc_getcaps {
  */
 #define I3C_CCC_GETCAPS_VTCAP1_SHARED_PERIPH_DETECT		BIT(5)
 
-/** Get Capabilities (GETCAPS) - VTCAP2 - Interrupt Requests bit shift value. */
-#define I3C_CCC_GETCAPS_VTCAP2_INTERRUPT_REQUESTS_SHIFT	0
-
 /** Get Capabilities (GETCAPS) - VTCAP2 - Interrupt Requests bitmask. */
-#define I3C_CCC_GETCAPS_VTCAP2_INTERRUPT_REQUESTS_MASK		\
-	(0x03U << I3C_CCC_GETCAPS_VTCAP2_INTERRUPT_REQUESTS_SHIFT)
+#define I3C_CCC_GETCAPS_VTCAP2_INTERRUPT_REQUESTS_MASK		GENMASK(1U, 0U)
 
 /**
  * @brief Get Capabilities (GETCAPS) - VTCAP2 - Interrupt Requests
@@ -1231,9 +1233,7 @@ union i3c_ccc_getcaps {
  * @param vtcap2 VTCAP2 value.
  */
 #define I3C_CCC_GETCAPS_VTCAP2_INTERRUPT_REQUESTS(vtcap2)	\
-	(((vtcap2) &						\
-	  I3C_CCC_GETCAPS_VTCAP2_INTERRUPT_REQUESTS_MASK)	\
-	 >> I3C_CCC_GETCAPS_VTCAP2_INTERRUPT_REQUESTS_SHIFT)
+	FIELD_GET(I3C_CCC_GETCAPS_VTCAP2_INTERRUPT_REQUESTS_MASK, (vtcap2))
 
 /**
  * @brief Get Virtual Target Capabilities Byte 2 (GETCAPS) Format 2 -
@@ -1241,12 +1241,8 @@ union i3c_ccc_getcaps {
  */
 #define I3C_CCC_GETCAPS_VTCAP2_ADDRESS_REMAPPING		BIT(2)
 
-/** Get Capabilities (GETCAPS) - VTCAP2 - Bus Context and Condition bit shift value. */
-#define I3C_CCC_GETCAPS_VTCAP2_BUS_CONTEXT_AND_COND_SHIFT	3
-
 /** Get Capabilities (GETCAPS) - VTCAP2 - Bus Context and Condition bitmask. */
-#define I3C_CCC_GETCAPS_VTCAP2_BUS_CONTEXT_AND_COND_MASK		\
-	(0x03U << I3C_CCC_GETCAPS_VTCAP2_BUS_CONTEXT_AND_COND_SHIFT)
+#define I3C_CCC_GETCAPS_VTCAP2_BUS_CONTEXT_AND_COND_MASK	GENMASK(4U, 3U)
 
 /**
  * @brief Get Capabilities (GETCAPS) - VTCAP2 - Bus Context and Condition
@@ -1257,9 +1253,7 @@ union i3c_ccc_getcaps {
  * @param vtcap2 VTCAP2 value.
  */
 #define I3C_CCC_GETCAPS_VTCAP2_BUS_CONTEXT_AND_COND(vtcap2)	\
-	(((vtcap2) &						\
-	  I3C_CCC_GETCAPS_VTCAP2_BUS_CONTEXT_AND_COND_MASK)	\
-	 >> I3C_CCC_GETCAPS_VTCAP2_BUS_CONTEXT_AND_COND_SHIFT)
+	FIELD_GET(I3C_CCC_GETCAPS_VTCAP2_BUS_CONTEXT_AND_COND_MASK, (vtcap2))
 
 /**
  * @brief Enum for I3C Reset Action (RSTACT) Defining Byte Values.
@@ -1279,7 +1273,106 @@ enum i3c_ccc_rstact_defining_byte {
 
 	/** Virtual Target Detect. */
 	I3C_CCC_RSTACT_VIRTUAL_TARGET_DETECT = 0x04U,
+
+	/** Return Time to Reset Peripheral */
+	I3C_CCC_RSTACT_RETURN_TIME_TO_RESET_PERIPHERAL = 0x81U,
+
+	/** Return Time to Reset Whole Target */
+	I3C_CCC_RSTACT_RETURN_TIME_TO_WHOLE_TARGET = 0x82U,
+
+	/** Return Time for Debug Network Adapter Reset */
+	I3C_CCC_RSTACT_RETURN_TIME_FOR_DEBUG_NETWORK_ADAPTER_RESET = 0x83U,
+
+	/** Return Virtual Target Indication */
+	I3C_CCC_RSTACT_RETURN_VIRTUAL_TARGET_INDICATION = 0x84U,
 };
+
+/**
+ * @name Set Bus Context MIPI I3C Specification v1.Y Minor Version (SETBUSCON)
+ * @anchor I3C_CCC_SETBUSCON_I3C_SPEC
+ *
+ * - CONTEXT[7:6]: 2'b00
+ *
+ * - CONTEXT[5]: I3C Specification Editorial Revision (within Minor Version)
+ *   - 0: Version 1.Y.0
+ *   - 1: Version 1.Y.1 or greater
+ *
+ * - CONTEXT[4]: I3C Specification Family
+ *   - 0: MIPI I3C Specification
+ *   - 1: MIPI I3C Basic Specification
+ *
+ * - CONTEXT[3:0]: I3C Specification Minor Version (v1.Y)
+ *   - 0: Illegal, do not use (see Note below)
+ *        (It would encode v1.0, but SETBUSCON was not available in I3C Basic v1.0)
+ *   - 1-15: Version 1.1 - Version 1.15
+ *
+ * Examples:  Bit[5]  Bit[4]   Bits[3:0]
+ *    I3C Basic v1.1.0:  1'b0 || 1'b1 || 4'b0001 or 8'b00010001
+ *    I3C Basic v1.1.1:  1'b1 || 1'b1 || 4'b0001 or 8'b00110001
+ *    I3C Basic v1.2.0:  1'b0 || 1'b1 || 4'b0010 or 8'b00010010
+ *
+ * @{
+ */
+
+/** I3C Specification Minor Version shift mask */
+#define I3C_CCC_SETBUSCON_I3C_SPEC_MINOR_VER_MASK		GENMASK(3U, 0U)
+
+/**
+ * @brief I3C Specification Minor Version (v1.Y)
+ *
+ * Set the context bits for SETBUSCON
+ *
+ * @param y I3C Specification Minor Version Number
+ */
+#define I3C_CCC_SETBUSCON_I3C_SPEC_MINOR_VER(y)			\
+	FIELD_PREP(I3C_CCC_SETBUSCON_I3C_SPEC_MINOR_VER_MASK, (y))
+
+/** MIPI I3C Specification */
+#define I3C_CCC_SETBUSCON_I3C_SPEC_I3C_SPEC			0
+
+/** MIPI I3C Basic Specification */
+#define I3C_CCC_SETBUSCON_I3C_SPEC_I3C_BASIC_SPEC		BIT(4)
+
+/** Version 1.Y.0 */
+#define I3C_CCC_SETBUSCON_I3C_SPEC_I3C_SPEC_EDITORIAL_1_Y_0	0
+
+/** Version 1.Y.1 or greater */
+#define I3C_CCC_SETBUSCON_I3C_SPEC_I3C_SPEC_EDITORIAL_1_Y_1	BIT(5)
+
+/** @} */
+
+/**
+ * @name Set Bus Context Other Standards Organizations (SETBUSCON)
+ * @anchor I3C_CCC_SETBUSCON_OTHER_STANDARDS
+ *
+ * @{
+ */
+
+/**
+ * @brief JEDEC Sideband
+ *
+ * JEDEC SideBand Bus device, compliant to JESD403 Specification v1.0 or later.
+ */
+#define I3C_CCC_SETBUSCON_OTHER_STANDARDS_JEDEC_SIDEBAND	128
+
+/**
+ * @brief MCTP
+ *
+ * MCTP for system manageability (conforming to the content protocol defined in
+ * the MCTP I3C Transport Binding Specification, released by DMTF, version 1.0
+ * or newer)
+ */
+#define I3C_CCC_SETBUSCON_OTHER_STANDARDS_MCTP			129
+
+/**
+ * @brief ETSI
+ *
+ * ETSI for Secure Smart Platform Devices used for mobile networks authentication
+ * and other ETSI security functions in mobile ecosystem
+ */
+#define I3C_CCC_SETBUSCON_OTHER_STANDARDS_ETSI			130
+
+/** @} */
 
 /**
  * @brief Test if I3C CCC payload is for broadcast.
@@ -1339,10 +1432,10 @@ int i3c_ccc_do_getpid(struct i3c_device_desc *target,
 		      struct i3c_ccc_getpid *pid);
 
 /**
- * @brief Broadcast RSTACT to reset I3C Peripheral.
+ * @brief Broadcast RSTACT to reset I3C Peripheral (Format 1).
  *
  * Helper function to broadcast Target Reset Action (RSTACT) to
- * all connected targets to Reset the I3C Peripheral Only (0x01).
+ * all connected targets.
  *
  * @param[in] controller Pointer to the controller device driver instance.
  * @param[in] action What reset action to perform.
@@ -1351,6 +1444,60 @@ int i3c_ccc_do_getpid(struct i3c_device_desc *target,
  */
 int i3c_ccc_do_rstact_all(const struct device *controller,
 			  enum i3c_ccc_rstact_defining_byte action);
+
+/**
+ * @brief Single target RSTACT to reset I3C Peripheral.
+ *
+ * Helper function to do Target Reset Action (RSTACT) to
+ * one target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[in] action What reset action to perform.
+ * @param[in] get True if a get, False if set
+ * @param[out] data Pointer to RSTACT payload received.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_rstact(const struct i3c_device_desc *target,
+			  enum i3c_ccc_rstact_defining_byte action,
+			  bool get,
+			  uint8_t *data);
+
+/**
+ * @brief Single target RSTACT to reset I3C Peripheral (Format 2).
+ *
+ * Helper function to do Target Reset Action (RSTACT, format 2) to
+ * one target. This is a Direct Write.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[in] action What reset action to perform.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_rstact_fmt2(const struct i3c_device_desc *target,
+			  enum i3c_ccc_rstact_defining_byte action)
+{
+	return i3c_ccc_do_rstact(target, action, false, NULL);
+}
+
+/**
+ * @brief Single target RSTACT to reset I3C Peripheral (Format 3).
+ *
+ * Helper function to do Target Reset Action (RSTACT, format 3) to
+ * one target. This is a Direct Read.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[in] action What reset action to perform.
+ * @param[out] data Pointer to RSTACT payload received.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_rstact_fmt3(const struct i3c_device_desc *target,
+			  enum i3c_ccc_rstact_defining_byte action,
+			  uint8_t *data)
+{
+	return i3c_ccc_do_rstact(target, action, true, data);
+}
 
 /**
  * @brief Broadcast RSTDAA to reset dynamic addresses for all targets.
@@ -1373,10 +1520,12 @@ int i3c_ccc_do_rstdaa_all(const struct device *controller);
  *
  * @param[in] target Pointer to the target device descriptor where
  *                   the device is configured with a static address.
+ * @param[in] da Struct of the Dynamic address
  *
  * @return @see i3c_do_ccc
  */
-int i3c_ccc_do_setdasa(const struct i3c_device_desc *target);
+int i3c_ccc_do_setdasa(const struct i3c_device_desc *target,
+			  struct i3c_ccc_address da);
 
 /**
  * @brief Set New Dynamic Address for a target
@@ -1387,7 +1536,7 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target);
  *
  * @param[in] target Pointer to the target device descriptor where
  *                   the device is configured with a static address.
- * @param[in] new_da Pointer to the new_da struct.
+ * @param[in] new_da Struct of the Dynamic address
  *
  * @return @see i3c_do_ccc
  */
@@ -1423,6 +1572,147 @@ int i3c_ccc_do_events_all_set(const struct device *controller,
  */
 int i3c_ccc_do_events_set(struct i3c_device_desc *target,
 			  bool enable, struct i3c_ccc_events *events);
+
+/**
+ * @brief Direct ENTAS to set the Activity State.
+ *
+ * Helper function to broadcast Activity State Command on a single
+ * target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[in] as Activity State level
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_entas(const struct i3c_device_desc *target, uint8_t as);
+
+/**
+ * @brief Direct ENTAS0
+ *
+ * Helper function to do ENTAS0 setting the minimum bus activity level to 1us
+ * on a single target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas0(const struct i3c_device_desc *target)
+{
+	return i3c_ccc_do_entas(target, 0);
+}
+
+/**
+ * @brief Direct ENTAS1
+ *
+ * Helper function to do ENTAS1 setting the minimum bus activity level to 100us
+ * on a single target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas1(const struct i3c_device_desc *target)
+{
+	return i3c_ccc_do_entas(target, 1);
+}
+
+/**
+ * @brief Direct ENTAS2
+ *
+ * Helper function to do ENTAS2 setting the minimum bus activity level to 2ms
+ * on a single target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas2(const struct i3c_device_desc *target)
+{
+	return i3c_ccc_do_entas(target, 2);
+}
+
+/**
+ * @brief Direct ENTAS3
+ *
+ * Helper function to do ENTAS3 setting the minimum bus activity level to 50ms
+ * on a single target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas3(const struct i3c_device_desc *target)
+{
+	return i3c_ccc_do_entas(target, 3);
+}
+
+/**
+ * @brief Broadcast ENTAS to set the Activity State.
+ *
+ * Helper function to broadcast Activity State Command.
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ * @param[in] as Activity State level
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_entas_all(const struct device *controller, uint8_t as);
+
+/**
+ * @brief Broadcast ENTAS0
+ *
+ * Helper function to do ENTAS0 setting the minimum bus activity level to 1us
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas0_all(const struct device *controller)
+{
+	return i3c_ccc_do_entas_all(controller, 0);
+}
+
+/**
+ * @brief Broadcast ENTAS1
+ *
+ * Helper function to do ENTAS1 setting the minimum bus activity level to 100us
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas1_all(const struct device *controller)
+{
+	return i3c_ccc_do_entas_all(controller, 1);
+}
+
+/**
+ * @brief Broadcast ENTAS2
+ *
+ * Helper function to do ENTAS2 setting the minimum bus activity level to 2ms
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas2_all(const struct device *controller)
+{
+	return i3c_ccc_do_entas_all(controller, 2);
+}
+
+/**
+ * @brief Broadcast ENTAS3
+ *
+ * Helper function to do ENTAS3 setting the minimum bus activity level to 50ms
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas3_all(const struct device *controller)
+{
+	return i3c_ccc_do_entas_all(controller, 3);
+}
 
 /**
  * @brief Broadcast SETMWL to Set Maximum Write Length.
@@ -1516,6 +1806,19 @@ int i3c_ccc_do_setmrl(const struct i3c_device_desc *target,
  */
 int i3c_ccc_do_getmrl(const struct i3c_device_desc *target,
 		      struct i3c_ccc_mrl *mrl);
+
+/**
+ * @brief Broadcast ENTTM
+ *
+ * Helper function to do ENTTM (Enter Test Mode) to all devices
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ * @param[in] defbyte Defining Byte for ENTTM.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_enttm(const struct device *controller,
+			 enum i3c_ccc_enttm_defbyte defbyte);
 
 /**
  * @brief Single target GETSTATUS to Get Target Status.
@@ -1636,6 +1939,201 @@ static inline int i3c_ccc_do_getcaps_fmt2(const struct i3c_device_desc *target,
 	return i3c_ccc_do_getcaps(target, caps,
 				    GETCAPS_FORMAT_2, defbyte);
 }
+
+/**
+ * @brief Single target to Set Vendor / Standard Extension CCC
+ *
+ * Helper function to set Vendor / Standard Extension CCC of
+ * one target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[in] id Vendor CCC ID.
+ * @param[in] payload Pointer to payload.
+ * @param[in] len Length of payload. 0 if no payload.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_setvendor(const struct i3c_device_desc *target,
+			uint8_t id,
+			uint8_t *payload,
+			size_t len);
+
+/**
+ * @brief Single target to Get Vendor / Standard Extension CCC
+ *
+ * Helper function to get Vendor / Standard Extension CCC of
+ * one target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[in] id Vendor CCC ID.
+ * @param[out] payload Pointer to payload.
+ * @param[in] len Maximum Expected Length of the payload
+ * @param[out] num_xfer Length of the received payload
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_getvendor(const struct i3c_device_desc *target,
+			uint8_t id,
+			uint8_t *payload,
+			size_t len,
+			size_t *num_xfer);
+
+/**
+ * @brief Single target to Get Vendor / Standard Extension CCC
+ * with a defining byte
+ *
+ * Helper function to get Vendor / Standard Extension CCC of
+ * one target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[in] id Vendor CCC ID.
+ * @param[in] defbyte Defining Byte
+ * @param[out] payload Pointer to payload.
+ * @param[in] len Maximum Expected Length of the payload
+ * @param[out] num_xfer Length of the received payload
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_getvendor_defbyte(const struct i3c_device_desc *target,
+			uint8_t id,
+			uint8_t defbyte,
+			uint8_t *payload,
+			size_t len,
+			size_t *num_xfer);
+
+/**
+ * @brief Broadcast Set Vendor / Standard Extension CCC
+ *
+ * Helper function to broadcast Vendor / Standard Extension CCC
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ * @param[in] id Vendor CCC ID.
+ * @param[in] payload Pointer to payload.
+ * @param[in] len Length of payload. 0 if no payload.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_setvendor_all(const struct device *controller,
+			uint8_t id,
+			uint8_t *payload,
+			size_t len);
+
+/**
+ * @brief Broadcast SETAASA to set all target's dynamic address to their
+ * static address.
+ *
+ * Helper function to set dynamic addresses of all connected targets to
+ * their static address.
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_setaasa_all(const struct device *controller);
+
+/**
+ * @brief Single target GETMXDS to Get Max Data Speed.
+ *
+ * Helper function to do GETMXDS (Get Max Data Speed) of
+ * one target.
+ *
+ * This should only be supported if Max Data Speed Limit Bit of
+ * the BCR is set
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[out] caps Pointer to GETMXDS payload.
+ * @param[in] fmt Which GETMXDS to use.
+ * @param[in] defbyte Defining Byte if using format 3.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_getmxds(const struct i3c_device_desc *target,
+			 union i3c_ccc_getmxds *caps,
+			 enum i3c_ccc_getmxds_fmt fmt,
+			 enum i3c_ccc_getmxds_defbyte defbyte);
+
+/**
+ * @brief Single target GETMXDS to Get Max Data Speed (Format 1).
+ *
+ * Helper function to do GETMXDS (Get Max Data Speed, format 1) of
+ * one target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[out] caps Pointer to GETMXDS payload.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_getmxds_fmt1(const struct i3c_device_desc *target,
+					    union i3c_ccc_getmxds *caps)
+{
+	return i3c_ccc_do_getmxds(target, caps,
+				    GETMXDS_FORMAT_1,
+				    GETMXDS_FORMAT_3_INVALID);
+}
+
+/**
+ * @brief Single target GETMXDS to Get Max Data Speed (Format 2).
+ *
+ * Helper function to do GETMXDS (Get Max Data Speed, format 2) of
+ * one target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[out] caps Pointer to GETMXDS payload.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_getmxds_fmt2(const struct i3c_device_desc *target,
+					    union i3c_ccc_getmxds *caps)
+{
+	return i3c_ccc_do_getmxds(target, caps,
+				    GETMXDS_FORMAT_2,
+					GETMXDS_FORMAT_3_INVALID);
+}
+
+/**
+ * @brief Single target GETMXDS to Get Max Data Speed (Format 3).
+ *
+ * Helper function to do GETMXDS (Get Max Data Speed, format 3) of
+ * one target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[out] caps Pointer to GETMXDS payload.
+ * @param[in] defbyte Defining Byte for GETMXDS format 3.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_getmxds_fmt3(const struct i3c_device_desc *target,
+					    union i3c_ccc_getmxds *caps,
+					    enum i3c_ccc_getmxds_defbyte defbyte)
+{
+	return i3c_ccc_do_getmxds(target, caps,
+				    GETMXDS_FORMAT_3, defbyte);
+}
+
+/**
+ * @brief Broadcast DEFTGTS
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ * @param[in] deftgts Pointer to the deftgts payload.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_deftgts_all(const struct device *controller,
+			   struct i3c_ccc_deftgts *deftgts);
+
+/**
+ * @brief Broadcast SETBUSCON to set the bus context
+ *
+ * Helper function to set the bus context of all connected targets.
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ * @param[in] context Pointer to context byte values
+ * @param[in] length Length of the context buffer
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_setbuscon(const struct device *controller,
+				uint8_t *context, uint16_t length);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -14,9 +14,10 @@
  * @{
  */
 
+#include <stdint.h>
+
 #include <zephyr/device.h>
-#include <zephyr/kernel.h>
-#include <zephyr/types.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
@@ -42,7 +43,9 @@ extern "C" {
  * @brief Structure initializer for i3c_device_id from devicetree instance
  *
  * This is equivalent to
- * <tt>I3C_DEVICE_ID_DT(DT_DRV_INST(inst))</tt>.
+ * @code{.c}
+ * I3C_DEVICE_ID_DT(DT_DRV_INST(inst))
+ * @endcode
  *
  * @param inst Devicetree instance number
  */
@@ -68,13 +71,17 @@ extern "C" {
 		       | DT_PROP_BY_IDX(node_id, reg, 2),		\
 		.init_dynamic_addr =					\
 			DT_PROP_OR(node_id, assigned_address, 0),	\
+		.supports_setaasa = DT_PROP(node_id, supports_setaasa), \
 	},
 
 /**
  * @brief Structure initializer for i3c_device_desc from devicetree instance
  *
  * This is equivalent to
- * <tt>I3C_DEVICE_DESC_DT(DT_DRV_INST(inst))</tt>.
+ *
+ * @code{.c}
+ * I3C_DEVICE_DESC_DT(DT_DRV_INST(inst))
+ * @endcode
  *
  * @param inst Devicetree instance number
  */
@@ -84,7 +91,7 @@ extern "C" {
 /**
  * @brief Structure initializer for i3c_device_desc from devicetree
  *
- * This is mainly used by <tt>I3C_DEVICE_ARRAY_DT()</tt> to only
+ * This is mainly used by I3C_DEVICE_ARRAY_DT() to only
  * create a struct if and only if it is an I3C device.
  */
 #define I3C_DEVICE_DESC_DT_FILTERED(node_id)				\
@@ -110,7 +117,9 @@ extern "C" {
  * @brief Array initializer for a list of i3c_device_desc from devicetree instance
  *
  * This is equivalent to
- * <tt>I3C_DEVICE_ARRAY_DT(DT_DRV_INST(inst))</tt>.
+ * @code{.c}
+ * I3C_DEVICE_ARRAY_DT(DT_DRV_INST(inst))
+ * @endcode
  *
  * @param inst Devicetree instance number of the I3C controller
  */
@@ -126,7 +135,7 @@ extern "C" {
  *
  * @param init_fn Name of the init function of the driver.
  *
- * @param pm PM device resources reference (NULL if device does not use PM).
+ * @param pm PM device resources reference (`NULL` if device does not use PM).
  *
  * @param data Pointer to the device's private data.
  *
@@ -151,7 +160,7 @@ extern "C" {
  * @brief Like I3C_TARGET_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number. This is replaced by
- * <tt>DT_DRV_COMPAT(inst)</tt> in the call to I3C_TARGET_DT_DEFINE().
+ * `DT_DRV_COMPAT(inst)` in the call to I3C_TARGET_DT_DEFINE().
  *
  * @param ... other parameters as expected by I3C_TARGET_DT_DEFINE().
  */
@@ -161,9 +170,8 @@ extern "C" {
 /**
  * @brief Structure initializer for i3c_i2c_device_desc from devicetree
  *
- * This helper macro expands to a static initializer for a <tt>struct
- * i3c_i2c_device_desc</tt> by reading the relevant bus and device data
- * from the devicetree.
+ * This helper macro expands to a static initializer for a i3c_i2c_device_desc
+ * by reading the relevant bus and device data from the devicetree.
  *
  * @param node_id Devicetree node identifier for the I3C device whose
  *                struct i3c_i2c_device_desc to create an initializer for
@@ -179,7 +187,9 @@ extern "C" {
  * @brief Structure initializer for i3c_i2c_device_desc from devicetree instance
  *
  * This is equivalent to
- * <tt>I3C_I2C_DEVICE_DESC_DT(DT_DRV_INST(inst))</tt>.
+ * @code{.c}
+ * I3C_I2C_DEVICE_DESC_DT(DT_DRV_INST(inst))
+ * @endcode
  *
  * @param inst Devicetree instance number
  */
@@ -190,7 +200,7 @@ extern "C" {
 /**
  * @brief Structure initializer for i3c_i2c_device_desc from devicetree
  *
- * This is mainly used by <tt>I3C_I2C_DEVICE_ARRAY_DT()</tt> to only
+ * This is mainly used by I3C_I2C_DEVICE_ARRAY_DT() to only
  * create a struct if and only if it is an I2C device.
  */
 #define I3C_I2C_DEVICE_DESC_DT_FILTERED(node_id)			\
@@ -216,7 +226,9 @@ extern "C" {
  * @brief Array initializer for a list of i3c_i2c_device_desc from devicetree instance
  *
  * This is equivalent to
- * <tt>I3C_I2C_DEVICE_ARRAY_DT(DT_DRV_INST(inst))</tt>.
+ * @code{.c}
+ * I3C_I2C_DEVICE_ARRAY_DT(DT_DRV_INST(inst))
+ * @endcode
  *
  * @param inst Devicetree instance number of the I3C controller
  */

--- a/include/zephyr/drivers/i3c/error_types.h
+++ b/include/zephyr/drivers/i3c/error_types.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Meta Platforms, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I3C_ERROR_TYPES_H_
+#define ZEPHYR_INCLUDE_DRIVERS_I3C_ERROR_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief I3C SDR Controller Error Types
+ *
+ * These are error types defined by the I3C specification.
+ *
+ * #I3C_ERROR_CE_UNKNOWN and #I3C_ERROR_CE_NONE are not
+ * official error types according to the specification.
+ * These are there simply to aid in error handling during
+ * interactions with the I3C drivers and subsystem.
+ */
+enum i3c_sdr_controller_error_types {
+	/** Transaction after sending CCC */
+	I3C_ERROR_CE0,
+
+	/** Monitoring Error */
+	I3C_ERROR_CE1,
+
+	/** No response to broadcast address (0x7E) */
+	I3C_ERROR_CE2,
+
+	/** Failed Controller Handoff */
+	I3C_ERROR_CE3,
+
+	/** Unknown error (not official error type) */
+	I3C_ERROR_CE_UNKNOWN,
+
+	/** No error (not official error type) */
+	I3C_ERROR_CE_NONE,
+
+	I3C_ERROR_CE_MAX = I3C_ERROR_CE_UNKNOWN,
+	I3C_ERROR_CE_INVALID,
+};
+
+/**
+ * @brief I3C SDR Target Error Types
+ *
+ * These are error types defined by the I3C specification.
+ *
+ * #I3C_ERROR_TE_UNKNOWN and #I3C_ERROR_TE_NONE are not
+ * official error types according to the specification.
+ * These are there simply to aid in error handling during
+ * interactions with the I3C drivers and subsystem.
+ */
+enum i3c_sdr_target_error_types {
+	/**
+	 * Invalid Broadcast Address or
+	 * Dynamic Address after DA assignment
+	 */
+	I3C_ERROR_TE0,
+
+	/** CCC type */
+	I3C_ERROR_TE1,
+
+	/** Write Data */
+	I3C_ERROR_TE2,
+
+	/** Assigned Address during Dynamic Address Arbitration */
+	I3C_ERROR_TE3,
+
+	/** 0x7E/R missing after RESTART during Dynamic Address Arbitration */
+	I3C_ERROR_TE4,
+
+	/** Transaction after detecting CCC */
+	I3C_ERROR_TE5,
+
+	/** Monitoring Error */
+	I3C_ERROR_TE6,
+
+	/** Dead Bus Recovery */
+	I3C_ERROR_DBR,
+
+	/** Unknown error (not official error type) */
+	I3C_ERROR_TE_UNKNOWN,
+
+	/** No error (not official error type) */
+	I3C_ERROR_TE_NONE,
+
+	I3C_ERROR_TE_MAX = I3C_ERROR_TE_UNKNOWN,
+	I3C_ERROR_TE_INVALID,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_I3C_ERROR_TYPES_H_ */

--- a/include/zephyr/drivers/i3c/hdr_ddr.h
+++ b/include/zephyr/drivers/i3c/hdr_ddr.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I3C_HDR_DDR_H_
+#define ZEPHYR_INCLUDE_DRIVERS_I3C_HDR_DDR_H_
+
+/**
+ * @brief I3C HDR DDR API
+ * @defgroup i3c_hdr_ddr I3C HDR DDR API
+ * @ingroup i3c_interface
+ * @{
+ */
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/drivers/i3c.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Write a set amount of data to an I3C target device with HDR DDR.
+ *
+ * This routine writes a set amount of data synchronously.
+ *
+ * @param target I3C target device descriptor.
+ * @param cmd 7-bit command code
+ * @param buf Memory pool from which the data is transferred.
+ * @param num_bytes Number of bytes to write.
+ *
+ * @retval 0 If successful.
+ * @retval -EBUSY Bus is busy.
+ * @retval -EIO General input / output error.
+ */
+static inline int i3c_hdr_ddr_write(struct i3c_device_desc *target, uint8_t cmd,
+				uint8_t *buf, uint32_t num_bytes)
+{
+	struct i3c_msg msg;
+
+	msg.buf = buf;
+	msg.len = num_bytes;
+	msg.flags = I3C_MSG_WRITE | I3C_MSG_STOP | I3C_MSG_HDR;
+	msg.hdr_mode = I3C_MSG_HDR_DDR;
+	msg.hdr_cmd_code = cmd;
+
+	return i3c_transfer(target, &msg, 1);
+}
+
+/**
+ * @brief Read a set amount of data from an I3C target device with HDR DDR.
+ *
+ * This routine reads a set amount of data synchronously.
+ *
+ * @param target I3C target device descriptor.
+ * @param cmd 7-bit command code
+ * @param buf Memory pool that stores the retrieved data.
+ * @param num_bytes Number of bytes to read.
+ *
+ * @retval 0 If successful.
+ * @retval -EBUSY Bus is busy.
+ * @retval -EIO General input / output error.
+ */
+static inline int i3c_hdr_ddr_read(struct i3c_device_desc *target, uint8_t cmd,
+				uint8_t *buf, uint32_t num_bytes)
+{
+	struct i3c_msg msg;
+
+	msg.buf = buf;
+	msg.len = num_bytes;
+	msg.flags = I3C_MSG_STOP | I3C_MSG_HDR;
+	msg.hdr_mode = I3C_MSG_HDR_DDR;
+	msg.hdr_cmd_code = cmd;
+
+	return i3c_transfer(target, &msg, 1);
+}
+
+/**
+ * @brief Write then read data from an I3C target device with HDR DDR.
+ *
+ * This supports the common operation "this is what I want", "now give
+ * it to me" transaction pair through a combined write-then-read bus
+ * transaction.
+ *
+ * @param target I3C target device descriptor.
+ * @param write_buf Pointer to the data to be written
+ * @param num_write Number of bytes to write
+ * @param write_cmd 7-bit command code for write
+ * @param read_buf Pointer to storage for read data
+ * @param num_read Number of bytes to read
+ * @param read_cmd 7-bit command code for read
+ *
+ * @retval 0 if successful
+ * @retval -EBUSY Bus is busy.
+ * @retval -EIO General input / output error.
+ */
+static inline int i3c_hdr_ddr_write_read(struct i3c_device_desc *target,
+				 const void *write_buf, size_t num_write, uint8_t read_cmd,
+				 void *read_buf, size_t num_read, uint8_t write_cmd)
+{
+	struct i3c_msg msg[2];
+
+	msg[0].buf = (uint8_t *)write_buf;
+	msg[0].len = num_write;
+	msg[0].flags = I3C_MSG_WRITE | I3C_MSG_HDR;
+	msg[0].hdr_mode = I3C_MSG_HDR_DDR;
+	msg[0].hdr_cmd_code = write_cmd;
+
+	msg[1].buf = (uint8_t *)read_buf;
+	msg[1].len = num_read;
+	msg[1].flags = I3C_MSG_RESTART | I3C_MSG_READ | I3C_MSG_HDR | I3C_MSG_STOP;
+	msg[1].hdr_mode = I3C_MSG_HDR_DDR;
+	msg[1].hdr_cmd_code = read_cmd;
+
+	return i3c_transfer(target, msg, 2);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_I3C_HDR_DDR_H_ */

--- a/include/zephyr/drivers/i3c/ibi.h
+++ b/include/zephyr/drivers/i3c/ibi.h
@@ -14,10 +14,11 @@
  * @{
  */
 
+#include <stdint.h>
+
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
-#include <zephyr/types.h>
-#include <zephyr/sys/util.h>
+#include <zephyr/sys/slist.h>
 
 #ifndef CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE
 #define CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE 0
@@ -86,13 +87,7 @@ struct i3c_ibi_payload {
  * @brief Node about a queued IBI.
  */
 struct i3c_ibi_work {
-	/**
-	 * @cond INTERNAL_HIDDEN
-	 *
-	 * Used for keeping track of work in a queue.
-	 */
 	sys_snode_t node;
-	/** @endcond */
 
 	/**
 	 * k_work struct.

--- a/include/zephyr/drivers/i3c/rtio.h
+++ b/include/zephyr/drivers/i3c/rtio.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ * Copyright (c) 2024 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_I3C_RTIO_H_
+#define ZEPHYR_DRIVERS_I3C_RTIO_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/rtio/rtio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Driver context for implementing i3c with rtio
+ */
+struct i3c_rtio {
+	struct k_sem lock;
+	struct k_spinlock slock;
+	struct rtio *r;
+	struct mpsc io_q;
+	struct rtio_iodev iodev;
+	struct rtio_iodev_sqe *txn_head;
+	struct rtio_iodev_sqe *txn_curr;
+	struct i3c_device_desc *i3c_desc;
+};
+
+/**
+ * @brief Statically define an i3c_rtio context
+ *
+ * @param _name Symbolic name of the context
+ * @param _sq_sz Submission queue entry pool size
+ * @param _cq_sz Completion queue entry pool size
+ */
+#define I3C_RTIO_DEFINE(_name, _sq_sz, _cq_sz)		\
+	RTIO_DEFINE(CONCAT(_name, _r), _sq_sz, _cq_sz);	\
+	static struct i3c_rtio _name = {		\
+		.r = &CONCAT(_name, _r),		\
+	};
+
+/**
+ * @brief Copy an array of i3c_msgs to rtio submissions and a transaction
+ *
+ * @retval sqe Last sqe setup in the copy
+ * @retval NULL Not enough memory to copy the transaction
+ */
+struct rtio_sqe *i3c_rtio_copy(struct rtio *r, struct rtio_iodev *iodev, const struct i3c_msg *msgs,
+			       uint8_t num_msgs);
+
+/**
+ * @brief Initialize an i3c rtio context
+ *
+ * @param ctx I3C RTIO driver context
+ */
+void i3c_rtio_init(struct i3c_rtio *ctx);
+
+/**
+ * @brief Signal that the current (ctx->txn_curr) submission has been completed
+ *
+ * @param ctx I3C RTIO driver context
+ * @param status Completion status, negative values are errors
+ *
+ * @retval true Next submission is ready to start
+ * @retval false No more submissions to work on
+ */
+bool i3c_rtio_complete(struct i3c_rtio *ctx, int status);
+
+/**
+ * @brief Submit, atomically, a submission to work on at some point
+ *
+ * @retval true Next submission is ready to start
+ * @retval false No new submission to start or submissions are in progress already
+ */
+bool i3c_rtio_submit(struct i3c_rtio *ctx, struct rtio_iodev_sqe *iodev_sqe);
+
+/**
+ * @brief Configure the I3C bus controller
+ *
+ * Provides a compatible API for the existing i3c_configure API, and blocks the
+ * caller until the transfer completes.
+ *
+ * See i3c_configure().
+ */
+int i3c_rtio_configure(struct i3c_rtio *ctx, enum i3c_config_type type, void *config);
+
+/**
+ * @brief Transfer i3c messages in a blocking call
+ *
+ * Provides a compatible API for the existing i3c_transfer API, and blocks the caller
+ * until the transfer completes.
+ *
+ * See i3c_transfer().
+ */
+int i3c_rtio_transfer(struct i3c_rtio *ctx, struct i3c_msg *msgs, uint8_t num_msgs,
+			       struct i3c_device_desc *desc);
+
+/**
+ * @brief Perform an I3C bus recovery in a blocking call
+ *
+ * Provides a compatible API for the existing i3c_recover API, and blocks the caller
+ * until the process completes.
+ *
+ * See i3c_recover().
+ */
+int i3c_rtio_recover(struct i3c_rtio *ctx);
+
+/**
+ * @brief Perform an I3C CCC in a blocking call
+ *
+ * Provides a compatible API for the existing i3c_do_ccc API, and blocks the caller
+ * until the process completes.
+ *
+ * See i3c_do_ccc().
+ */
+int i3c_rtio_ccc(struct i3c_rtio *ctx, struct i3c_ccc_payload *payload);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRVIERS_I3C_RTIO_H_ */

--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -14,10 +14,12 @@
  * @{
  */
 
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/device.h>
-#include <zephyr/kernel.h>
-#include <zephyr/types.h>
-#include <zephyr/sys/util.h>
+#include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,7 +41,15 @@ struct i3c_config_target {
 	bool enable;
 
 	/**
-	 * I3C target address.
+	 * I3C target dynamic address.
+	 *
+	 * Used when operates as secondary controller
+	 * or as a target device.
+	 */
+	uint8_t dynamic_addr;
+
+	/**
+	 * I3C target static address.
 	 *
 	 * Used used when operates as secondary controller
 	 * or as a target device.
@@ -90,7 +100,6 @@ struct i3c_config_target {
  * reference to i3c_target_register().
  */
 struct i3c_target_config {
-	/** Private, do not modify */
 	sys_snode_t node;
 
 	/**
@@ -193,6 +202,49 @@ struct i3c_target_callbacks {
 	int (*read_processed_cb)(struct i3c_target_config *config,
 				 uint8_t *val);
 
+#ifdef CONFIG_I3C_TARGET_BUFFER_MODE
+	/** @brief Function called when a write to the device is completed.
+	 *
+	 * This function is invoked by the controller when it completes
+	 * reception of data from the source buffer to the destination
+	 * buffer in an ongoing write operation to the device.
+	 *
+	 * @param config Configuration structure associated with the
+	 *               device to which the operation is addressed.
+	 *
+	 * @param ptr pointer to the buffer that contains the data to be transferred.
+	 *
+	 * @param len the length of the data to be transferred.
+	 */
+	void (*buf_write_received_cb)(struct i3c_target_config *config, uint8_t *ptr, uint32_t len);
+
+	/** @brief Function called when a read from the device is initiated.
+	 *
+	 * This function is invoked by the controller when the bus is ready to
+	 * provide additional data by buffer for a read operation from the address
+	 * associated with the device.
+	 *
+	 * The value returned in @p **ptr and @p *len will be transmitted. A success
+	 * return shall cause the controller to react to additional read operations.
+	 * An error return shall cause the controller to ignore bus operations until
+	 * a new start condition is received.
+	 *
+	 * @param config the configuration structure associated with the
+	 * device to which the operation is addressed.
+	 *
+	 * @param ptr pointer to storage for the address of data buffer to return
+	 * for the read request.
+	 *
+	 * @param len pointer to storage for the length of the data to be transferred
+	 * for the read request.
+	 *
+	 * @param hdr_mode HDR mode
+	 *
+	 * @return 0 if data has been provided, or a negative error code.
+	 */
+	int (*buf_read_requested_cb)(struct i3c_target_config *config, uint8_t **ptr, uint32_t *len,
+				     uint8_t *hdr_mode);
+#endif
 	/**
 	 * @brief Function called when a stop condition is observed after a
 	 * start condition addressed to a particular device.
@@ -233,14 +285,15 @@ __subsystem struct i3c_target_driver_api {
  *            driver configured in target mode.
  * @param buf Pointer to the buffer
  * @param len Length of the buffer
+ * @param hdr_mode HDR mode see @c I3C_MSG_HDR_MODE*
  *
  * @retval Total number of bytes written
- * @retval -ENOTSUP Not in Target Mode
+ * @retval -ENOTSUP Not in Target Mode or HDR Mode not supported
  * @retval -ENOSPC No space in Tx FIFO
  * @retval -ENOSYS If target mode is not implemented
  */
 static inline int i3c_target_tx_write(const struct device *dev,
-				      uint8_t *buf, uint16_t len)
+				      uint8_t *buf, uint16_t len, uint8_t hdr_mode)
 {
 	const struct i3c_driver_api *api =
 		(const struct i3c_driver_api *)dev->api;
@@ -249,7 +302,7 @@ static inline int i3c_target_tx_write(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	return api->target_tx_write(dev, buf, len);
+	return api->target_tx_write(dev, buf, len, hdr_mode);
 }
 
 /**

--- a/soc/nuvoton/nct/nct66/soc_reg_def.h
+++ b/soc/nuvoton/nct/nct66/soc_reg_def.h
@@ -2219,6 +2219,26 @@ enum nct_i3c_mctrl_type {
 #define NCT_I3C_HDRCMD_CMD0		FIELD(0, 8)
 #define NCT_I3C_ID_ID			FIELD(0, 32)
 
+/* CTRL register options */
+#define CTRL_EVENT_NORMAL    0
+#define CTRL_EVENT_IBI       1
+#define CTRL_EVENT_CNTLR_REQ 2
+#define CTRL_EVENT_HJ        3
+
+/* STATUS register options */
+#define STATUS_EVDET_NONE            0
+#define STATUS_EVDET_REQ_NOT_SENT    1
+#define STATUS_EVDET_REQ_SENT_NACKED 2
+#define STATUS_EVDET_REQ_SENT_ACKED  3
+
+/* DMACTRL options */
+#define DMA_DMAFB_DISABLE		0x0
+#define DMA_DMAFB_EN_ONE_FRAME		0x1
+#define DMA_DMAFB_EN_MANUAL		0x2
+#define DMA_DMATB_DISABLE		0x0
+#define DMA_DMATB_EN_ONE_FRAME		0x1
+#define DMA_DMATB_EN_MANUAL		0x2
+
 struct pdma_dsct_reg {
 	volatile uint32_t CTL;
 	volatile uint32_t SA;


### PR DESCRIPTION
Based from alan's v3.7, https://github.com/Nuvoton-Israel/zephyr/tree/alan/npcm-main_i3c_target
- Setup rx dma before calling nct_i3c_target_STOP_handler
- Add synchronization to let i3c target doesn't free tx data buffer before all tx data send out.
- Add nuvoton,nct-i3c-ext-device driver to prevent compile error for I3C_DEVICE_ARRAY_DT_INST()
- Support mqueue driver for i3c slave for openbic using v2.6
- Use malloc to replace k_calloc and k_malloc

 
 